### PR TITLE
feat: Add Polkadot Cloud RPC, use in production

### DIFF
--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -25,6 +25,9 @@ export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'
 export const AssetHubPolkadotSubscanURL = 'https://assethub-polkadot.subscan.io'
 export const ManualSigners = ['ledger', 'vault', 'wallet_connect']
 
+// RPC
+export const PolkadotCloudRpcStatemintUrl = 'wss://rpc.polkadot.cloud/statemint'
+
 // Element Thresholds
 export const SideMenuHiddenWidth = 250
 export const SideMenuMaximisedWidth = 145

--- a/packages/consts/src/rpc.ts
+++ b/packages/consts/src/rpc.ts
@@ -2,19 +2,25 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainId, RpcEndpoints } from 'types'
+import { PolkadotCloudRpcStatemintUrl } from '.'
 
 export type RpcChainId = ChainId | 'hydration'
 
+const isProduction =
+	(import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD === true
+
 export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
-	polkadot: {
-		'Automata 1RPC': 'wss://1rpc.io/dot',
-		// Dwellir: 'wss://polkadot-rpc.dwellir.com',
-		// IBP1: 'wss://rpc.ibp.network/polkadot',
-		// IBP2: 'wss://rpc.dotters.network/polkadot',
-		LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
-		OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-		Stakeworld: 'wss://dot-rpc.stakeworld.io',
-	},
+	polkadot: isProduction
+		? { 'Polkadot Cloud': PolkadotCloudRpcStatemintUrl }
+		: {
+				'Automata 1RPC': 'wss://1rpc.io/dot',
+				// Dwellir: 'wss://polkadot-rpc.dwellir.com',
+				// IBP1: 'wss://rpc.ibp.network/polkadot',
+				// IBP2: 'wss://rpc.dotters.network/polkadot',
+				LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
+				OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
+				Stakeworld: 'wss://dot-rpc.stakeworld.io',
+			},
 	kusama: {
 		'Automata 1RPC': 'wss://1rpc.io/ksm',
 		// Dwellir: 'wss://kusama-rpc.dwellir.com',


### PR DESCRIPTION
## Summary

- Add a shared constant for the Polkadot Cloud Statemint WebSocket endpoint.
- Use Polkadot Cloud as the only Polkadot RPC provider in production.
- Keep the existing public Polkadot RPC providers available in development.
- Leave Kusama, Paseo, and system-chain provider configuration unchanged.

## Behavior

In production, persisted selections for the previous Polkadot providers no longer validate against the available endpoint map, so startup falls back to Polkadot Cloud. Automatic RPC mode also receives only the Polkadot Cloud endpoint.

Development continues to use the existing provider list.

## Verification

- `pnpm --filter consts check`
- TypeScript validation
- Confirmed the production bundle includes Polkadot Cloud and excludes the previous Polkadot fallback endpoints
- Confirmed the development bundle retains the existing providers
