### PR TITLE
revert: Polkadot Cloud RPC production override

### DIFF
--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -25,9 +25,6 @@ export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'
 export const AssetHubPolkadotSubscanURL = 'https://assethub-polkadot.subscan.io'
 export const ManualSigners = ['ledger', 'vault', 'wallet_connect']
 
-// RPC
-export const PolkadotCloudRpcStatemintUrl = 'wss://rpc.polkadot.cloud/statemint'
-
 // Element Thresholds
 export const SideMenuHiddenWidth = 250
 export const SideMenuMaximisedWidth = 145

--- a/packages/consts/src/rpc.ts
+++ b/packages/consts/src/rpc.ts
@@ -2,25 +2,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainId, RpcEndpoints } from 'types'
-import { PolkadotCloudRpcStatemintUrl } from '.'
 
 export type RpcChainId = ChainId | 'hydration'
 
-const isProduction =
-	(import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD === true
-
 export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
-	polkadot: isProduction
-		? { 'Polkadot Cloud': PolkadotCloudRpcStatemintUrl }
-		: {
-				'Automata 1RPC': 'wss://1rpc.io/dot',
-				// Dwellir: 'wss://polkadot-rpc.dwellir.com',
-				// IBP1: 'wss://rpc.ibp.network/polkadot',
-				// IBP2: 'wss://rpc.dotters.network/polkadot',
-				LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
-				OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
-				Stakeworld: 'wss://dot-rpc.stakeworld.io',
-			},
+	polkadot: {
+		'Automata 1RPC': 'wss://1rpc.io/dot',
+		// Dwellir: 'wss://polkadot-rpc.dwellir.com',
+		// IBP1: 'wss://rpc.ibp.network/polkadot',
+		// IBP2: 'wss://rpc.dotters.network/polkadot',
+		LuckyFriday: 'wss://rpc-polkadot.luckyfriday.io',
+		OnFinality: 'wss://polkadot.api.onfinality.io/public-ws',
+		Stakeworld: 'wss://dot-rpc.stakeworld.io',
+	},
 	kusama: {
 		'Automata 1RPC': 'wss://1rpc.io/ksm',
 		// Dwellir: 'wss://kusama-rpc.dwellir.com',


### PR DESCRIPTION
## Summary

Reverts #3747.

- Remove the Polkadot Cloud Statemint RPC constant.
- Remove the production-only Polkadot RPC override.
- Restore the previous Polkadot RPC provider list in all environments.

## Why

The production override introduced an error after deployment. This rollback restores the previously working RPC configuration while the correct cloud endpoint integration is investigated.

## Impact

Production returns to selecting from the existing Polkadot RPC providers. Kusama, Paseo, and system-chain configuration are unchanged.

## Verification

- `pnpm --filter consts check`
- `pnpm --filter app-staking exec tsc --noEmit --skipLibCheck`
- `git diff --check origin/main...HEAD`
