### PR TITLE
fix: use Polkadot Cloud RPC for statemint

### DIFF
--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -25,6 +25,9 @@ export const DiscordSupportURL = 'https://discord.gg/QY7CSSJm3D'
 export const AssetHubPolkadotSubscanURL = 'https://assethub-polkadot.subscan.io'
 export const ManualSigners = ['ledger', 'vault', 'wallet_connect']
 
+// RPC
+export const PolkadotCloudRpcStatemintUrl = 'wss://rpc.polkadot.cloud/statemint'
+
 // Element Thresholds
 export const SideMenuHiddenWidth = 250
 export const SideMenuMaximisedWidth = 145

--- a/packages/consts/src/rpc.ts
+++ b/packages/consts/src/rpc.ts
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainId, RpcEndpoints } from 'types'
+import { PolkadotCloudRpcStatemintUrl } from '.'
 
 export type RpcChainId = ChainId | 'hydration'
+
+const isProduction =
+	(import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD === true
 
 export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
 	polkadot: {
@@ -53,15 +57,17 @@ export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
 		Amforc: 'wss://people-paseo.rpc.amforc.com',
 		Rotko: 'wss://people-paseo.rotko.net',
 	},
-	statemint: {
-		DeServe: 'wss://asset-hub.polkadot.rpc.deserve.network',
-		// LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
-		// Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
-		StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
-		// Dwellir: 'wss://asset-hub-polkadot-rpc.dwellir.com',
-		// IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
-		// IBP2: 'wss://asset-hub-polkadot.dotters.network',
-	},
+	statemint: isProduction
+		? { 'Polkadot Cloud': PolkadotCloudRpcStatemintUrl }
+		: {
+				DeServe: 'wss://asset-hub.polkadot.rpc.deserve.network',
+				// LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
+				// Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',
+				StakeWorld: 'wss://dot-rpc.stakeworld.io/assethub',
+				// Dwellir: 'wss://asset-hub-polkadot-rpc.dwellir.com',
+				// IBP1: 'wss://sys.ibp.network/asset-hub-polkadot',
+				// IBP2: 'wss://asset-hub-polkadot.dotters.network',
+			},
 	statemine: {
 		LuckyFriday: 'wss://rpc-asset-hub-kusama.luckyfriday.io',
 		Parity: 'wss://kusama-asset-hub-rpc.polkadot.io',


### PR DESCRIPTION
## Summary

- Add the Polkadot Cloud Statemint WebSocket endpoint constant.
- Use Polkadot Cloud as the only Statemint RPC provider in production.
- Keep the Polkadot relay-chain RPC configuration unchanged.
- Keep the existing Statemint providers in development.

## Root cause

#3747 applied the Statemint endpoint to the `polkadot` relay-chain entry in `RpcEndpointsByChain`. This caused the relay-chain client to connect to an Asset Hub endpoint.

This change places the production override under `statemint`, where the endpoint belongs.

## Behavior

In production, persisted Statemint provider selections no longer validate against the available endpoint map, so startup falls back to Polkadot Cloud. The Polkadot relay chain continues using its existing provider list.

Development behavior is unchanged.

## Verification

- `pnpm --filter consts check`
- `pnpm --filter app-staking exec tsc --noEmit --skipLibCheck`
- `git diff --check`
- Confirmed the production bundle contains Polkadot Cloud and the existing relay-chain providers, while excluding the Statemint fallback providers
- Confirmed the development bundle retains the existing relay-chain and Statemint providers
