### PR TITLE
feat(ux): Confirm re-generate optimal selection

### DIFF
--- a/packages/app-staking/src/library/GenerateNominations/ConfirmAction.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/ConfirmAction.tsx
@@ -1,0 +1,54 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useTheme } from 'hooks/useTheme'
+import { Confirm } from 'library/Prompt/Confirm'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { Popover } from 'ui-core/popover'
+
+export const ConfirmAction = ({
+	align = 'end',
+	children,
+	controlKey,
+	disabled = false,
+	onConfirm,
+	text,
+}: {
+	align?: 'start' | 'center' | 'end'
+	children: ReactNode
+	controlKey: string
+	disabled?: boolean
+	onConfirm: () => void
+	text: string
+}) => {
+	const { themeElementRef } = useTheme()
+	const [open, setOpen] = useState(false)
+
+	const confirm = () => {
+		onConfirm()
+		setOpen(false)
+	}
+
+	return (
+		<Popover
+			align={align}
+			content={
+				<Confirm
+					controlKey={controlKey}
+					onClose={() => setOpen(false)}
+					onRevert={confirm}
+					text={text}
+				/>
+			}
+			disabled={disabled}
+			onOpenChange={setOpen}
+			open={open}
+			portalContainer={themeElementRef.current || undefined}
+			side="bottom"
+			sideOffset={8}
+		>
+			{children}
+		</Popover>
+	)
+}

--- a/packages/app-staking/src/library/GenerateNominations/Controls/InlineControls.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/Controls/InlineControls.tsx
@@ -5,6 +5,7 @@ import { useManageNominations } from 'contexts/ManageNominations'
 import { SelectableWrapper } from 'library/List'
 import { useTranslation } from 'react-i18next'
 import { ButtonPrimary, ButtonSecondary } from 'ui-buttons'
+import { ConfirmAction } from '../ConfirmAction'
 import type { InlineControlsProps } from './types'
 
 export const InlineControls = ({ displayFor }: InlineControlsProps) => {
@@ -21,12 +22,14 @@ export const InlineControls = ({ displayFor }: InlineControlsProps) => {
 
 	return (
 		<SelectableWrapper>
-			{allowRegenerate && (
-				<ButtonType
-					text={t('reGenerate', { ns: 'app' })}
-					onClick={() => revertNominations()}
-				/>
-			)}
+			<ConfirmAction
+				align="start"
+				controlKey="regenerate_nominations"
+				onConfirm={revertNominations}
+				text={t('regenerateNominationSelection', { ns: 'modals' })}
+			>
+				<ButtonType asLabel text={t('reGenerate', { ns: 'app' })} />
+			</ConfirmAction>
 		</SelectableWrapper>
 	)
 }

--- a/packages/app-staking/src/library/GenerateNominations/Controls/MenuControls.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/Controls/MenuControls.tsx
@@ -4,6 +4,7 @@
 import { useManageNominations } from 'contexts/ManageNominations'
 import { useTranslation } from 'react-i18next'
 import { ButtonMenu } from 'ui-buttons'
+import { ConfirmAction } from '../ConfirmAction'
 import { Revert } from '../Revert'
 import type { MenuControlsProps } from './types'
 import { MenuWrapper } from './Wrappers'
@@ -36,14 +37,18 @@ export const MenuControls = ({
 					/>
 				)}
 				{method && (
-					<ButtonMenu
-						text={t('reGenerate', { ns: 'app' })}
-						onClick={() => {
+					<ConfirmAction
+						align="start"
+						controlKey="regenerate_nominations"
+						onConfirm={() => {
 							setMethod('Optimal Selection')
 							setNominations([])
 							setFetching(true)
 						}}
-					/>
+						text={t('regenerateNominationSelection', { ns: 'modals' })}
+					>
+						<ButtonMenu asLabel text={t('reGenerate', { ns: 'app' })} />
+					</ConfirmAction>
 				)}
 				{(allowRevert || action) && (
 					<div className="actions">

--- a/packages/app-staking/src/library/GenerateNominations/Revert.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/Revert.tsx
@@ -1,12 +1,9 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useTheme } from 'hooks/useTheme'
-import { Confirm } from 'library/Prompt/Confirm'
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ButtonSecondary } from 'ui-buttons'
-import { Popover } from 'ui-core/popover'
+import { ConfirmAction } from './ConfirmAction'
 
 export const Revert = ({
 	disabled,
@@ -16,31 +13,13 @@ export const Revert = ({
 	onClick: () => void
 }) => {
 	const { t } = useTranslation('modals')
-	const { themeElementRef } = useTheme()
-	const [open, setOpen] = useState(false)
-
-	const onRevert = () => {
-		onClick()
-		setOpen(false)
-	}
 
 	return (
-		<Popover
-			open={open}
-			onOpenChange={setOpen}
+		<ConfirmAction
+			controlKey="revert_nominations"
 			disabled={disabled}
-			portalContainer={themeElementRef.current || undefined}
-			side="bottom"
-			align="end"
-			sideOffset={8}
-			content={
-				<Confirm
-					text={t('revertNominationChanges')}
-					controlKey="revert_nominations"
-					onClose={() => setOpen(false)}
-					onRevert={onRevert}
-				/>
-			}
+			onConfirm={onClick}
+			text={t('revertNominationChanges')}
 		>
 			<ButtonSecondary
 				asLabel
@@ -49,6 +28,6 @@ export const Revert = ({
 				text={t('revertChanges')}
 				disabled={disabled}
 			/>
-		</Popover>
+		</ConfirmAction>
 	)
 }

--- a/packages/locales/src/resources/de/modals.json
+++ b/packages/locales/src/resources/de/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Aktuelle Epochenpunkte",
 		"recipient": "Empfänger",
 		"refreshAccounts": "Konten aktualisieren",
+		"regenerateNominationSelection": "Möchtest du deine Nominierungen wirklich neu generieren? Dadurch wird deine aktuelle Validatorenauswahl ersetzt.",
 		"remove": "Entfernen",
 		"removeAccount": "Konto entfernen",
 		"removeBond": "Bindung aufheben",

--- a/packages/locales/src/resources/en/modals.json
+++ b/packages/locales/src/resources/en/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Recent Era Points",
 		"recipient": "Recipient",
 		"refreshAccounts": "Refresh Accounts",
+		"regenerateNominationSelection": "Are you sure you want to re-generate your nominations? This will replace your current validator selection.",
 		"remove": "Remove",
 		"removeAccount": "Remove Account",
 		"removeBond": "Remove Bond",

--- a/packages/locales/src/resources/es/modals.json
+++ b/packages/locales/src/resources/es/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Puntos de Era Recientes",
 		"recipient": "Destinatario",
 		"refreshAccounts": "Actualizar Cuentas",
+		"regenerateNominationSelection": "¿Seguro que quieres volver a generar tus nominaciones? Esto reemplazará tu selección actual de validadores.",
 		"remove": "Eliminar",
 		"removeAccount": "Eliminar Cuenta",
 		"removeBond": "Eliminar Vinculación",

--- a/packages/locales/src/resources/fr/modals.json
+++ b/packages/locales/src/resources/fr/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Points d'ère récents",
 		"recipient": "Destinataire",
 		"refreshAccounts": "Actualiser les comptes",
+		"regenerateNominationSelection": "Voulez-vous vraiment régénérer vos nominations ? Cela remplacera votre sélection actuelle de validateurs.",
 		"remove": "Supprimer",
 		"removeAccount": "Supprimer le compte",
 		"removeBond": "Supprimer l'engagement",

--- a/packages/locales/src/resources/ja/modals.json
+++ b/packages/locales/src/resources/ja/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "最近のエラポイント",
 		"recipient": "受取人",
 		"refreshAccounts": "アカウントを更新",
+		"regenerateNominationSelection": "ノミネーションを再生成してもよろしいですか？現在のバリデーター選択は置き換えられます。",
 		"remove": "削除",
 		"removeAccount": "アカウントを削除",
 		"removeBond": "ボンドを削除",

--- a/packages/locales/src/resources/ko/modals.json
+++ b/packages/locales/src/resources/ko/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "최근 에라 포인트",
 		"recipient": "수취인",
 		"refreshAccounts": "계정 새로고침",
+		"regenerateNominationSelection": "추천을 다시 생성하시겠습니까? 현재 검증인 선택이 대체됩니다.",
 		"remove": "제거",
 		"removeAccount": "계정 제거",
 		"removeBond": "본드 제거",

--- a/packages/locales/src/resources/pt/modals.json
+++ b/packages/locales/src/resources/pt/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Pontos de Era Recentes",
 		"recipient": "Destinatário",
 		"refreshAccounts": "Atualizar Contas",
+		"regenerateNominationSelection": "Tem certeza de que deseja gerar novamente suas nomeações? Isso substituirá sua seleção atual de validadores.",
 		"remove": "Remover",
 		"removeAccount": "Remover Conta",
 		"removeBond": "Remover Vínculo",

--- a/packages/locales/src/resources/ru/modals.json
+++ b/packages/locales/src/resources/ru/modals.json
@@ -249,6 +249,7 @@
 		"recentEraPoints": "Недавние очки эры",
 		"recipient": "Получатель",
 		"refreshAccounts": "Обновить аккаунты",
+		"regenerateNominationSelection": "Вы уверены, что хотите повторно сгенерировать номинации? Текущий выбор валидаторов будет заменён.",
 		"remove": "Удалить",
 		"removeAccount": "Удалить аккаунт",
 		"removeBond": "Убрать блокировку",

--- a/packages/locales/src/resources/tr/modals.json
+++ b/packages/locales/src/resources/tr/modals.json
@@ -241,6 +241,7 @@
 		"recentEraPoints": "Son Era Puanları",
 		"recipient": "Alıcı",
 		"refreshAccounts": "Hesapları Yenile",
+		"regenerateNominationSelection": "Adaylıklarınızı yeniden oluşturmak istediğinizden emin misiniz? Mevcut doğrulayıcı seçiminiz değiştirilecektir.",
 		"remove": "Kaldır",
 		"removeAccount": "Hesabı Kaldır",
 		"removeBond": "Bağlamayı Kaldır",

--- a/packages/locales/src/resources/zh/modals.json
+++ b/packages/locales/src/resources/zh/modals.json
@@ -233,6 +233,7 @@
 		"recentEraPoints": "最近Era点数",
 		"recipient": "接收人",
 		"refreshAccounts": "刷新账户",
+		"regenerateNominationSelection": "您确定要重新生成提名吗？这将替换您当前选择的验证者。",
 		"remove": "解除",
 		"removeAccount": "删除帐户",
 		"removeBond": "解除质押",


### PR DESCRIPTION
## Summary

Adds a confirmation prompt before re-generating an optimal validator selection, preventing users from accidentally overwriting their current nominations.

## Changes

- Adds confirmation to both inline and manage-nominations Re-generate actions.
- Introduces a reusable `ConfirmAction` component.
- Refactors Revert Changes to use the shared confirmation behavior.
- Adds localized confirmation copy for all supported languages.

## Testing

- Confirmed cancelling preserves the current validator selection.
- Confirmed accepting generates a new optimal selection.
- Confirmed Revert Changes continues to work.
- Passed TypeScript, Biome, locale validation, and production build checks.