### PR TITLE
feat(refactor): Remove legacy extensions 

### DIFF
--- a/packages/app-nominate/src/env.d.ts
+++ b/packages/app-nominate/src/env.d.ts
@@ -5,9 +5,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 
 declare global {
 	interface Window {
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		injectedWeb3?: Record<string, ExtensionInjected>
 		opera?: boolean
 	}

--- a/packages/app-staking/src/env.d.ts
+++ b/packages/app-staking/src/env.d.ts
@@ -5,9 +5,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 
 declare global {
 	interface Window {
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		injectedWeb3?: Record<string, ExtensionInjected>
 		opera?: boolean
 	}

--- a/packages/app-swap/src/env.d.ts
+++ b/packages/app-swap/src/env.d.ts
@@ -6,9 +6,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 declare global {
 	interface Window {
 		injectedWeb3?: Record<string, ExtensionInjected>
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		opera?: boolean
 	}
 }

--- a/packages/app-validators/src/env.d.ts
+++ b/packages/app-validators/src/env.d.ts
@@ -5,9 +5,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 
 declare global {
 	interface Window {
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		injectedWeb3?: Record<string, ExtensionInjected>
 		opera?: boolean
 	}

--- a/packages/tx-submit/src/env.d.ts
+++ b/packages/tx-submit/src/env.d.ts
@@ -5,9 +5,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 
 declare global {
 	interface Window {
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		injectedWeb3?: Record<string, ExtensionInjected>
 		opera?: boolean
 	}

--- a/packages/ui-app/src/Headers/Popovers/ConnectPopover/Extension.tsx
+++ b/packages/ui-app/src/Headers/Popovers/ConnectPopover/Extension.tsx
@@ -32,12 +32,7 @@ export const Extension = ({ extension, last, setOpen }: ExtensionProps) => {
 	const canConnect = extensionCanConnect(id)
 	const connected = extensionsStatus[id] === 'connected'
 
-	// Get the correct icon id for the extension.
-	const iconId =
-		window?.walletExtension?.isNovaWallet && id === 'polkadot-js'
-			? 'nova-wallet'
-			: id
-	const Icon = ExtensionIcons[iconId]
+	const Icon = ExtensionIcons[id]
 	const disabled = !isInstalled
 
 	// Handle connect and disconnect from extension.

--- a/packages/ui-app/src/Headers/Popovers/ConnectPopover/index.tsx
+++ b/packages/ui-app/src/Headers/Popovers/ConnectPopover/index.tsx
@@ -27,14 +27,11 @@ export const ConnectPopover = ({ setOpen }: SetOpenProp) => {
 	// Whether the app is running on mobile
 	const isMobile = mobileCheck()
 
-	// Whether the app is running in Nova Wallet
-	const inNova = !!window?.walletExtension?.isNovaWallet || false
-
 	// Whether the app is running in a SubWallet Mobile
 	const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && isMobile
 
 	// NOTE: Deprecated support for these wallets/extensions
-	const deprecated = ['snap', 'polkagate', 'fearless']
+	const deprecated = ['snap', 'polkagate', 'fearless', 'enkrypt']
 
 	// Format supported extensions as array
 	const extensionsAsArray = Object.entries(extensions)
@@ -44,23 +41,13 @@ export const ConnectPopover = ({ setOpen }: SetOpenProp) => {
 		}))
 		.filter(({ id }) => !deprecated.some((d) => id.includes(d)))
 
-	// Determine which web extensions to display. Only display Subwallet Mobile or Nova if in one of
-	// those environments. In Nova Wallet's case, fetch `nova-wallet` metadata and overwrite
-	// `polkadot-js` with it. Otherwise, keep all `web-extension` category items
+	// Determine which web extensions to display. Only display Subwallet Mobile if in one of those
+	// environments.
 	const web = inSubWallet
 		? extensionsAsArray.filter((a) => a.id === 'subwallet-js')
-		: inNova
-			? extensionsAsArray
-					.filter((a) => a.id === 'nova-wallet')
-					.map((a) => ({ ...a, id: 'polkadot-js' }))
-			: // Otherwise, keep all extensions except `polkadot-js`.
-				extensionsAsArray.filter((a) => a.category === 'web-extension')
+		: extensionsAsArray.filter((a) => a.category === 'web-extension')
 
 	const installed = web.filter((a) => a.id in extensionsStatus)
-	// NOTE: Moving `enkrypt` to last item
-	installed.sort((a, b) =>
-		a.id === 'enkrypt' ? 1 : b.id === 'enkrypt' ? -1 : 0,
-	)
 
 	const installedIds = new Set(installed.map((a) => a.id))
 	const other = web.filter((a) => !installedIds.has(a.id))

--- a/packages/ui-app/src/Headers/Popovers/ConnectPopover/index.tsx
+++ b/packages/ui-app/src/Headers/Popovers/ConnectPopover/index.tsx
@@ -12,7 +12,6 @@ import { ConnectItem } from 'ui-core/popover'
 import { Proxies } from './Proxies'
 import { ReadOnly } from './ReadOnly'
 import type { SetOpenProp } from './types'
-import { mobileCheck } from './Utils'
 import { Wallets } from './Wallets'
 
 export const ConnectPopover = ({ setOpen }: SetOpenProp) => {
@@ -23,12 +22,6 @@ export const ConnectPopover = ({ setOpen }: SetOpenProp) => {
 	const [selectedSection, setSelectedConnectItem] = useState<string>('wallets')
 
 	const popoverRef = useRef<HTMLDivElement>(null)
-
-	// Whether the app is running on mobile
-	const isMobile = mobileCheck()
-
-	// Whether the app is running in a SubWallet Mobile
-	const inSubWallet = !!window.injectedWeb3?.['subwallet-js'] && isMobile
 
 	// NOTE: Deprecated support for these wallets/extensions
 	const deprecated = ['snap', 'polkagate', 'fearless', 'enkrypt']
@@ -41,11 +34,8 @@ export const ConnectPopover = ({ setOpen }: SetOpenProp) => {
 		}))
 		.filter(({ id }) => !deprecated.some((d) => id.includes(d)))
 
-	// Determine which web extensions to display. Only display Subwallet Mobile if in one of those
-	// environments.
-	const web = inSubWallet
-		? extensionsAsArray.filter((a) => a.id === 'subwallet-js')
-		: extensionsAsArray.filter((a) => a.category === 'web-extension')
+	// Determine which web extensions to display.
+	const web = extensionsAsArray.filter((a) => a.category === 'web-extension')
 
 	const installed = web.filter((a) => a.id in extensionsStatus)
 

--- a/packages/ui-app/src/env.d.ts
+++ b/packages/ui-app/src/env.d.ts
@@ -5,9 +5,6 @@ import type { ExtensionInjected } from '@w3ux/types'
 
 declare global {
 	interface Window {
-		walletExtension?: {
-			isNovaWallet?: boolean
-		}
 		injectedWeb3?: Record<string, ExtensionInjected>
 		opera?: boolean
 	}


### PR DESCRIPTION
Removes legacy wallet-specific handling and related global typings from extension connection flows.

**Changes:**
- Deprecates Enkrypt and simplifies web-extension filtering.
- Removes Nova Wallet-specific icon and detection logic.
- Removes obsolete `walletExtension` window typings.
