### PR TITLE
feat: Add nominator retainment warning

### DIFF
--- a/packages/app-staking/src/library/GenerateNominations/NominationHealth.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/NominationHealth.tsx
@@ -3,6 +3,7 @@
 
 import { RetainmentThresholds } from 'consts/retainment'
 import { useNominationHealth } from 'hooks/useNominationHealth'
+import { RetainmentThresholdDanger } from 'library/NominationRetainmentWarning'
 import { useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Validator } from 'types'
@@ -130,13 +131,7 @@ export const NominationHealth = ({
 					})}
 				</StatusCard>
 			)}
-			{dangerCount > 0 && (
-				<StatusCard status="danger" role="status">
-					{t('retainmentThresholdDanger', {
-						count: dangerCount,
-					})}
-				</StatusCard>
-			)}
+			<RetainmentThresholdDanger count={dangerCount} />
 		</NominationHealthWrapper>
 	)
 }

--- a/packages/app-staking/src/library/GenerateNominations/NominationsView.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/NominationsView.tsx
@@ -37,11 +37,6 @@ export const NominationsView = ({
 }: NominationsViewProps) => {
 	// Resolve shared application state before deriving view conditions.
 	const { t } = useTranslation()
-	const { activeAddress } = useActiveAccount()
-	const { accountsInitialised, isReadOnlyAccount } = useImportedAccounts()
-	const { isReady } = useApi()
-	const { active: healthCheckActive, retainmentStatsEnabled } =
-		useNominationHealth()
 	const {
 		fetching,
 		height,
@@ -52,11 +47,22 @@ export const NominationsView = ({
 		setMethod,
 		setNominations,
 	} = useManageNominations()
+	const { isReady } = useApi()
+	const { active: healthCheckActive, retainmentStatsEnabled } =
+		useNominationHealth()
+	const { activeAddress } = useActiveAccount()
+	const { accountsInitialised, isReadOnlyAccount } = useImportedAccounts()
 
 	// Derive layout and visibility once for use across both presentation modes.
 	const listReady = isReady && method !== null
+
+	// Use rows when retainment stats are enabled.
 	const listFormat = retainmentStatsEnabled ? 'row' : 'col'
+
+	// Show method selection until a method is chosen.
 	const showMethodSelection = !isReadOnlyAccount(activeAddress) && !method
+
+	// Show standalone controls when nominations can be managed.
 	const showStandaloneControls =
 		Boolean(activeAddress) &&
 		canManageNominations &&

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.module.scss
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.module.scss
@@ -1,0 +1,8 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+.fixButton {
+	border-color: color-mix(in srgb, var(--status-danger) 95%, black);
+	border-radius: var(--btn-sm-radius);
+	font-size: 1.1rem;
+}

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
-import { useActiveAccount } from '@polkadot-cloud/connect'
+import { useActiveAccount, useImportedAccounts } from '@polkadot-cloud/connect'
 import { RetainmentThresholds } from 'consts/retainment'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useActivePool } from 'hooks/useActivePool'
@@ -60,6 +60,7 @@ export const NominationRetainmentWarning = ({
 	const { openCanvas } = useOverlay().canvas
 	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
+	const { isReadOnlyAccount } = useImportedAccounts()
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
 	const { activePool, activePoolNominations, isOwner } = useActivePool()
 
@@ -85,7 +86,10 @@ export const NominationRetainmentWarning = ({
 
 	// Only display warnings when retainment data is available.
 	const canDisplay =
-		retainmentStatsEnabled && Boolean(activeAddress) && (!forPool || poolOwner)
+		!isReadOnlyAccount(activeAddress) &&
+		retainmentStatsEnabled &&
+		Boolean(activeAddress) &&
+		(!forPool || poolOwner)
 
 	// Load retainment details for the nominated validators.
 	const validatorDetails = useValidatorDetails(

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -9,7 +9,6 @@ import { useBalances } from 'hooks/useBalances'
 import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { getValidatorsWithRetainment } from 'library/GenerateNominations/utils'
 import { useValidatorDetails } from 'library/ValidatorList/useValidatorDetails'
-import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { BondFor } from 'types'
 import { ButtonPrimary } from 'ui-buttons'
@@ -56,36 +55,55 @@ export const NominationRetainmentWarning = ({
 }: {
 	bondFor?: BondFor
 }) => {
-	const { activeAddress } = useActiveAccount()
 	const { getNominations } = useBalances()
-	const { formatWithPrefs } = useValidators()
-	const { activePool, activePoolNominations, isOwner } = useActivePool()
 	const { openCanvas } = useOverlay().canvas
+	const { formatWithPrefs } = useValidators()
+	const { activeAddress } = useActiveAccount()
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
-	const forPool = bondFor === 'pool' || (bondFor === undefined && isOwner())
-	const effectiveBondFor = forPool ? 'pool' : 'nominator'
+	const { activePool, activePoolNominations, isOwner } = useActivePool()
+
+	// Check whether the active account owns the pool.
+	const poolOwner = isOwner()
+
+	// Resolve whether to manage pool or nominator nominations.
+	const effectiveBondFor: BondFor =
+		bondFor ?? (poolOwner ? 'pool' : 'nominator')
+
+	// Check whether pool nominations are being managed.
+	const forPool = effectiveBondFor === 'pool'
+
+	// Get the nominations for the resolved staking type.
 	const nominations = formatWithPrefs(
 		forPool
 			? (activePoolNominations?.targets ?? [])
 			: getNominations(activeAddress),
 	)
+
+	// Get the validator addresses needed for detail lookup.
 	const validatorAddresses = nominations.map(({ address }) => address)
-	const canDisplay = Boolean(activeAddress) && (!forPool || isOwner())
+
+	// Only display warnings when retainment data is available.
+	const canDisplay =
+		retainmentStatsEnabled && Boolean(activeAddress) && (!forPool || poolOwner)
+
+	// Load retainment details for the nominated validators.
 	const validatorDetails = useValidatorDetails(
 		validatorAddresses,
-		retainmentStatsEnabled && canDisplay && nominations.length > 0,
+		canDisplay && nominations.length > 0,
 	)
-	const dangerCount = useMemo(
-		() =>
-			getValidatorsWithRetainment(
-				nominations,
-				validatorDetails.retainmentByAddress,
-			).filter(({ rate }) => rate < RetainmentThresholds.medium).length,
-		[nominations, validatorDetails.retainmentByAddress],
-	)
-	const previewCount =
-		canDisplay && nominations.length > 0 ? PREVIEW_DANGER_COUNT : 0
-	const displayedDangerCount = dangerCount || previewCount
+
+	// Count nominees below the retainment threshold.
+	const dangerCount = getValidatorsWithRetainment(
+		nominations,
+		validatorDetails.retainmentByAddress,
+	).filter(({ rate }) => rate < RetainmentThresholds.medium).length
+
+	// Fall back to the development preview when needed.
+	const displayedDangerCount =
+		dangerCount ||
+		(canDisplay && nominations.length > 0 ? PREVIEW_DANGER_COUNT : 0)
+
+	// Open the nomination manager for the resolved staking type.
 	const handleFix = () => {
 		openCanvas({
 			key: 'ManageNominations',

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { useActiveAccount } from '@polkadot-cloud/connect'
 import { RetainmentThresholds } from 'consts/retainment'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
@@ -40,6 +41,8 @@ export const RetainmentThresholdDanger = ({
 					/>
 				) : undefined
 			}
+			icon={faCircleExclamation}
+			iconFrame={false}
 			status="danger"
 			role="status"
 		>

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -16,8 +16,6 @@ import { Page, StatusCard } from 'ui-core/base'
 import { useOverlay } from 'ui-overlay'
 import classes from './index.module.scss'
 
-const PREVIEW_DANGER_COUNT = import.meta.env.MODE === 'development' ? 1 : 0
-
 export const RetainmentThresholdDanger = ({
 	count,
 	onFix,
@@ -98,11 +96,6 @@ export const NominationRetainmentWarning = ({
 		validatorDetails.retainmentByAddress,
 	).filter(({ rate }) => rate < RetainmentThresholds.medium).length
 
-	// Fall back to the development preview when needed.
-	const displayedDangerCount =
-		dangerCount ||
-		(canDisplay && nominations.length > 0 ? PREVIEW_DANGER_COUNT : 0)
-
 	// Open the nomination manager for the resolved staking type.
 	const handleFix = () => {
 		openCanvas({
@@ -119,17 +112,14 @@ export const NominationRetainmentWarning = ({
 		})
 	}
 
-	if (!canDisplay || displayedDangerCount === 0) {
+	if (!canDisplay || dangerCount === 0) {
 		return null
 	}
 
 	return (
 		<Page.Row yMargin>
 			<Page.RowSection standalone>
-				<RetainmentThresholdDanger
-					count={displayedDangerCount}
-					onFix={handleFix}
-				/>
+				<RetainmentThresholdDanger count={dangerCount} onFix={handleFix} />
 			</Page.RowSection>
 		</Page.Row>
 	)

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -1,0 +1,118 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useActiveAccount } from '@polkadot-cloud/connect'
+import { RetainmentThresholds } from 'consts/retainment'
+import { useValidators } from 'contexts/Validators/ValidatorEntries'
+import { useActivePool } from 'hooks/useActivePool'
+import { useBalances } from 'hooks/useBalances'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
+import { getValidatorsWithRetainment } from 'library/GenerateNominations/utils'
+import { useValidatorDetails } from 'library/ValidatorList/useValidatorDetails'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { BondFor } from 'types'
+import { ButtonPrimary } from 'ui-buttons'
+import { Page, StatusCard } from 'ui-core/base'
+import { useOverlay } from 'ui-overlay'
+import classes from './index.module.scss'
+
+const PREVIEW_DANGER_COUNT = import.meta.env.MODE === 'development' ? 1 : 0
+
+export const RetainmentThresholdDanger = ({
+	count,
+	onFix,
+}: {
+	count: number
+	onFix?: () => void
+}) => {
+	const { t } = useTranslation('app')
+
+	if (count === 0) {
+		return null
+	}
+
+	return (
+		<StatusCard
+			action={
+				onFix ? (
+					<ButtonPrimary
+						className={classes.fixButton}
+						onClick={onFix}
+						text={t('fixIssues')}
+					/>
+				) : undefined
+			}
+			status="danger"
+			role="status"
+		>
+			{t('retainmentThresholdDanger', { count })}
+		</StatusCard>
+	)
+}
+
+export const NominationRetainmentWarning = ({
+	bondFor,
+}: {
+	bondFor?: BondFor
+}) => {
+	const { activeAddress } = useActiveAccount()
+	const { getNominations } = useBalances()
+	const { formatWithPrefs } = useValidators()
+	const { activePool, activePoolNominations, isOwner } = useActivePool()
+	const { openCanvas } = useOverlay().canvas
+	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const forPool = bondFor === 'pool' || (bondFor === undefined && isOwner())
+	const effectiveBondFor = forPool ? 'pool' : 'nominator'
+	const nominations = formatWithPrefs(
+		forPool
+			? (activePoolNominations?.targets ?? [])
+			: getNominations(activeAddress),
+	)
+	const validatorAddresses = nominations.map(({ address }) => address)
+	const canDisplay = Boolean(activeAddress) && (!forPool || isOwner())
+	const validatorDetails = useValidatorDetails(
+		validatorAddresses,
+		retainmentStatsEnabled && canDisplay && nominations.length > 0,
+	)
+	const dangerCount = useMemo(
+		() =>
+			getValidatorsWithRetainment(
+				nominations,
+				validatorDetails.retainmentByAddress,
+			).filter(({ rate }) => rate < RetainmentThresholds.medium).length,
+		[nominations, validatorDetails.retainmentByAddress],
+	)
+	const previewCount =
+		canDisplay && nominations.length > 0 ? PREVIEW_DANGER_COUNT : 0
+	const displayedDangerCount = dangerCount || previewCount
+	const handleFix = () => {
+		openCanvas({
+			key: 'ManageNominations',
+			options: {
+				bondFor: effectiveBondFor,
+				nominated: nominations,
+				nominator: forPool
+					? (activePool?.addresses?.stash ?? null)
+					: activeAddress,
+			},
+			scroll: false,
+			variant: 'card',
+		})
+	}
+
+	if (!canDisplay || displayedDangerCount === 0) {
+		return null
+	}
+
+	return (
+		<Page.Row yMargin>
+			<Page.RowSection standalone>
+				<RetainmentThresholdDanger
+					count={displayedDangerCount}
+					onFix={handleFix}
+				/>
+			</Page.RowSection>
+		</Page.Row>
+	)
+}

--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -61,14 +61,19 @@ export const NominationRetainmentWarning = ({
 	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
-	const { activePool, activePoolNominations, isOwner } = useActivePool()
+	const {
+		activePool,
+		activePoolNominations,
+		isNominator,
+		isOwner,
+	} = useActivePool()
 
-	// Check whether the active account owns the pool.
-	const poolOwner = isOwner()
+	// Check whether the active account can manage the pool's nominations.
+	const canManagePoolNominations = isOwner() || isNominator()
 
 	// Resolve whether to manage pool or nominator nominations.
 	const effectiveBondFor: BondFor =
-		bondFor ?? (poolOwner ? 'pool' : 'nominator')
+		bondFor ?? (canManagePoolNominations ? 'pool' : 'nominator')
 
 	// Check whether pool nominations are being managed.
 	const forPool = effectiveBondFor === 'pool'
@@ -85,7 +90,9 @@ export const NominationRetainmentWarning = ({
 
 	// Only display warnings when retainment data is available.
 	const canDisplay =
-		retainmentStatsEnabled && Boolean(activeAddress) && (!forPool || poolOwner)
+		retainmentStatsEnabled &&
+		Boolean(activeAddress) &&
+		(!forPool || canManagePoolNominations)
 
 	// Load retainment details for the nominated validators.
 	const validatorDetails = useValidatorDetails(

--- a/packages/app-staking/src/pages/Nominate/Active/index.tsx
+++ b/packages/app-staking/src/pages/Nominate/Active/index.tsx
@@ -8,7 +8,6 @@ import { useStaking } from 'hooks/useStaking'
 import { useNominatorStats } from 'hooks/useStats'
 import { useSyncing } from 'hooks/useSyncing'
 import { BondManager } from 'library/BondManager'
-import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { Nominations } from 'library/Nominations'
 import { Empty } from 'library/Nominations/Empty'
 import { Stats } from 'library/Stats'
@@ -34,7 +33,6 @@ export const Active = () => {
 
 	return (
 		<>
-			<NominationRetainmentWarning bondFor="nominator" />
 			<Stat.Row>
 				<Stats
 					items={[activeNominators, minimumNominatorBond, minimumActiveStake]}

--- a/packages/app-staking/src/pages/Nominate/Active/index.tsx
+++ b/packages/app-staking/src/pages/Nominate/Active/index.tsx
@@ -8,6 +8,7 @@ import { useStaking } from 'hooks/useStaking'
 import { useNominatorStats } from 'hooks/useStats'
 import { useSyncing } from 'hooks/useSyncing'
 import { BondManager } from 'library/BondManager'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { Nominations } from 'library/Nominations'
 import { Empty } from 'library/Nominations/Empty'
 import { Stats } from 'library/Stats'
@@ -33,6 +34,7 @@ export const Active = () => {
 
 	return (
 		<>
+			<NominationRetainmentWarning bondFor="nominator" />
 			<Stat.Row>
 				<Stats
 					items={[activeNominators, minimumNominatorBond, minimumActiveStake]}

--- a/packages/app-staking/src/pages/Nominate/index.tsx
+++ b/packages/app-staking/src/pages/Nominate/index.tsx
@@ -3,6 +3,7 @@
 
 import { onTabVisitEvent } from 'event-tracking'
 import { usePlugins } from 'hooks/usePlugins'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { PageTabs } from 'ui-app/PageTabs'
@@ -52,6 +53,7 @@ export const Nominate = () => {
 					}
 				/>
 			</Page.Title>
+			<NominationRetainmentWarning />
 			{activeTab === 0 && <Active />}
 			{activeTab === 1 && <NominationGeo />}
 		</Wrapper>

--- a/packages/app-staking/src/pages/Overview/index.tsx
+++ b/packages/app-staking/src/pages/Overview/index.tsx
@@ -6,6 +6,7 @@ import { useBalances } from 'hooks/useBalances'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
 import { useSyncing } from 'hooks/useSyncing'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { useTranslation } from 'react-i18next'
 import { CardWrapper } from 'ui-app/Card'
 import { Page } from 'ui-core/base'
@@ -37,6 +38,7 @@ export const Overview = () => {
 	return (
 		<>
 			<Page.Title title={t('overview')} />
+			<NominationRetainmentWarning />
 			{isBonding &&
 				!syncing &&
 				accountSynced(activeAddress) &&

--- a/packages/app-staking/src/pages/Pools/index.tsx
+++ b/packages/app-staking/src/pages/Pools/index.tsx
@@ -18,7 +18,7 @@ export const Pools = () => {
 		<>
 			<Page.Title title={t('pool', { ns: 'app' })}></Page.Title>
 			<PageWarnings />
-			<NominationRetainmentWarning bondFor="pool" />
+			<NominationRetainmentWarning />
 			<Stat.Row>
 				<Stats items={[activePools, minimumToJoinPool, minimumToCreatePool]} />
 			</Stat.Row>

--- a/packages/app-staking/src/pages/Pools/index.tsx
+++ b/packages/app-staking/src/pages/Pools/index.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { usePoolStats } from 'hooks/useStats'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { PageWarnings } from 'library/PageWarnings'
 import { Stats } from 'library/Stats'
 import { useTranslation } from 'react-i18next'
@@ -17,6 +18,7 @@ export const Pools = () => {
 		<>
 			<Page.Title title={t('pool', { ns: 'app' })}></Page.Title>
 			<PageWarnings />
+			<NominationRetainmentWarning bondFor="pool" />
 			<Stat.Row>
 				<Stats items={[activePools, minimumToJoinPool, minimumToCreatePool]} />
 			</Stat.Row>

--- a/packages/app-staking/src/pages/Rewards/index.tsx
+++ b/packages/app-staking/src/pages/Rewards/index.tsx
@@ -12,6 +12,7 @@ import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
 import { useStaking } from 'hooks/useStaking'
 import { useSyncing } from 'hooks/useSyncing'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import {
 	fetchPoolEraRewards,
 	fetchPoolRewards,
@@ -182,6 +183,7 @@ export const Rewards = () => {
 					preloaderTabs={1}
 				/>
 			</Page.Title>
+			<NominationRetainmentWarning />
 			{activeTab === 0 && (
 				<Overview
 					{...pageProps}

--- a/packages/app-staking/src/pages/Stake/index.tsx
+++ b/packages/app-staking/src/pages/Stake/index.tsx
@@ -5,6 +5,7 @@ import { useActiveAccount } from '@polkadot-cloud/connect'
 import { useAccountBalances } from 'hooks/useAccountBalances'
 import { useStakeStats } from 'hooks/useStats'
 import { useSyncing } from 'hooks/useSyncing'
+import { NominationRetainmentWarning } from 'library/NominationRetainmentWarning'
 import { PageWarnings } from 'library/PageWarnings'
 import { Stats } from 'library/Stats'
 import { Active } from 'pages/Nominate/Active'
@@ -37,6 +38,7 @@ export const Stake = () => {
 		<>
 			<Page.Title title={t('stake')} />
 			<PageWarnings />
+			<NominationRetainmentWarning />
 			{!nominating && (
 				<Stat.Row>
 					<Stats items={[averageRewardRate, minimumToJoinPool, nextReward]} />

--- a/packages/ui-core/src/base/StatusCard/index.module.scss
+++ b/packages/ui-core/src/base/StatusCard/index.module.scss
@@ -55,6 +55,11 @@
 	justify-content: center;
 }
 
+.unframedIcon {
+	border: 0;
+	font-size: 1.6rem;
+}
+
 .copy {
 	color: var(--status-card-text);
 	display: flex;

--- a/packages/ui-core/src/base/StatusCard/index.module.scss
+++ b/packages/ui-core/src/base/StatusCard/index.module.scss
@@ -79,3 +79,8 @@
 		font-size: 1.1rem;
 	}
 }
+
+.action {
+	flex: 0 0 auto;
+	margin-left: auto;
+}

--- a/packages/ui-core/src/base/StatusCard/index.tsx
+++ b/packages/ui-core/src/base/StatusCard/index.tsx
@@ -20,11 +20,13 @@ const STATUS_ICONS = {
 type StatusCardStatus = keyof typeof STATUS_ICONS
 
 type StatusCardProps = Omit<ComponentPropsWithoutRef<'div'>, 'title'> & {
+	action?: ReactNode
 	status: StatusCardStatus
 	title?: ReactNode
 }
 
 export const StatusCard = ({
+	action,
 	children,
 	className,
 	status,
@@ -44,5 +46,6 @@ export const StatusCard = ({
 			{title && <strong>{title}</strong>}
 			<span>{children}</span>
 		</div>
+		{action && <div className={classes.action}>{action}</div>}
 	</div>
 )

--- a/packages/ui-core/src/base/StatusCard/index.tsx
+++ b/packages/ui-core/src/base/StatusCard/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import {
 	faCheck,
 	faExclamation,
@@ -21,6 +22,8 @@ type StatusCardStatus = keyof typeof STATUS_ICONS
 
 type StatusCardProps = Omit<ComponentPropsWithoutRef<'div'>, 'title'> & {
 	action?: ReactNode
+	icon?: IconDefinition
+	iconFrame?: boolean
 	status: StatusCardStatus
 	title?: ReactNode
 }
@@ -29,6 +32,8 @@ export const StatusCard = ({
 	action,
 	children,
 	className,
+	icon,
+	iconFrame = true,
 	status,
 	title,
 	...props
@@ -38,8 +43,13 @@ export const StatusCard = ({
 		className={classNames(classes.statusCard, classes[status], className)}
 	>
 		<div className={classes.icon}>
-			<span aria-hidden className={classes.statusIcon}>
-				<FontAwesomeIcon icon={STATUS_ICONS[status]} />
+			<span
+				aria-hidden
+				className={classNames(classes.statusIcon, {
+					[classes.unframedIcon]: !iconFrame,
+				})}
+			>
+				<FontAwesomeIcon icon={icon ?? STATUS_ICONS[status]} />
 			</span>
 		</div>
 		<div className={classes.copy}>


### PR DESCRIPTION
Adds retainment-risk warnings across staking pages with a direct nomination-management action.

**Changes:**
- Extends `StatusCard` with an action slot.
- Adds a reusable nomination retainment warning.
- Displays warnings across relevant staking pages.
