### PR TITLE
feat(refactor): Unify warning ui

### DIFF
--- a/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
+++ b/packages/app-staking/src/library/NominationRetainmentWarning/index.tsx
@@ -125,7 +125,7 @@ export const NominationRetainmentWarning = ({
 	}
 
 	return (
-		<Page.Row yMargin>
+		<Page.Row yMargin="compact">
 			<Page.RowSection standalone>
 				<RetainmentThresholdDanger count={dangerCount} onFix={handleFix} />
 			</Page.RowSection>

--- a/packages/app-staking/src/library/PageWarnings/index.tsx
+++ b/packages/app-staking/src/library/PageWarnings/index.tsx
@@ -1,32 +1,29 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useWarnings } from 'hooks/useWarnings'
-import { Badge, Page } from 'ui-core/base'
+import { Page, StatusCard } from 'ui-core/base'
 
 export const PageWarnings = () => {
 	const { warningMessages } = useWarnings()
 
 	return (
 		<>
-			{warningMessages.length > 0 && (
-				<Page.Row yMargin>
+			{warningMessages.map(({ value, label, description, format, faIcon }) => (
+				<Page.Row yMargin="compact" key={value}>
 					<Page.RowSection standalone>
-						{warningMessages.map(
-							({ value, label, description, format, faIcon }) => (
-								<Badge.Container format={format} styled vList key={value}>
-									<Badge.Inner variant={format}>
-										<FontAwesomeIcon icon={faIcon} />
-										{description}
-										{label && <span>{label}</span>}
-									</Badge.Inner>
-								</Badge.Container>
-							),
-						)}
+						<StatusCard
+							icon={faIcon}
+							iconFrame={false}
+							status={format}
+							role="status"
+						>
+							{description}
+							{label && ` ${label}`}
+						</StatusCard>
 					</Page.RowSection>
 				</Page.Row>
-			)}
+			))}
 		</>
 	)
 }

--- a/packages/ui-core/src/base/Page/Row/index.module.scss
+++ b/packages/ui-core/src/base/Page/Row/index.module.scss
@@ -12,3 +12,7 @@
 .yMargin {
 	margin: 1rem 0;
 }
+
+.compactYMargin {
+	margin: 0.5rem 0;
+}

--- a/packages/ui-core/src/base/Page/Row/index.tsx
+++ b/packages/ui-core/src/base/Page/Row/index.tsx
@@ -12,7 +12,8 @@ import classes from './index.module.scss'
  */
 export const Row = ({ children, style, yMargin }: RowProps) => {
 	const buttonClasses = classNames(classes.row, 'pagePadding', {
-		[classes.yMargin]: yMargin,
+		[classes.yMargin]: yMargin === true,
+		[classes.compactYMargin]: yMargin === 'compact',
 	})
 
 	return (

--- a/packages/ui-core/src/base/Page/Row/index.tsx
+++ b/packages/ui-core/src/base/Page/Row/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import classNames from 'classnames'
-import type { RowProps } from '../../types'
+import type { PageRowProps } from '../../types'
 import classes from './index.module.scss'
 
 /**
@@ -10,7 +10,7 @@ import classes from './index.module.scss'
  * @summary Used to separate page content based on rows. Commonly used with `RowPrimary` and
  * `RowSecondary`.
  */
-export const Row = ({ children, style, yMargin }: RowProps) => {
+export const Row = ({ children, style, yMargin }: PageRowProps) => {
 	const buttonClasses = classNames(classes.row, 'pagePadding', {
 		[classes.yMargin]: yMargin === true,
 		[classes.compactYMargin]: yMargin === 'compact',

--- a/packages/ui-core/src/base/types.ts
+++ b/packages/ui-core/src/base/types.ts
@@ -4,7 +4,7 @@
 import type { ComponentBase } from 'types'
 
 export type RowProps = ComponentBase & {
-	yMargin?: boolean
+	yMargin?: boolean | 'compact'
 	xMargin?: boolean
 }
 

--- a/packages/ui-core/src/base/types.ts
+++ b/packages/ui-core/src/base/types.ts
@@ -4,8 +4,12 @@
 import type { ComponentBase } from 'types'
 
 export type RowProps = ComponentBase & {
-	yMargin?: boolean | 'compact'
+	yMargin?: boolean
 	xMargin?: boolean
+}
+
+export type PageRowProps = ComponentBase & {
+	yMargin?: boolean | 'compact'
 }
 
 export type TooltipAreaProps = ComponentBase & {


### PR DESCRIPTION
Unifies staking warnings with the shared `StatusCard` UI and introduces compact page-row spacing.

**Changes:**
- Adds compact vertical margins to `Page.Row`.
- Migrates staking warnings to `StatusCard`.
- Aligns nomination-retainment warning spacing.
