### PR TITLE
feat(ux): Header menu link revision, links to footer

### DIFF
--- a/packages/app-nominate/src/Headers.tsx
+++ b/packages/app-nominate/src/Headers.tsx
@@ -14,7 +14,6 @@ const menuPopoverFeatures = {
 	helpPrompts: false,
 	share: false,
 	plugins: false,
-	docs: false,
 	syncAccounts: false,
 	sendModal: false,
 } satisfies MenuPopoverFeatureFlags

--- a/packages/app-nominate/src/Router.tsx
+++ b/packages/app-nominate/src/Router.tsx
@@ -85,7 +85,7 @@ const RouterInner = () => {
 									<Route path="*" element={<Navigate to="/" replace />} />
 								</Routes>
 							</ErrorBoundary>
-							<MainFooter />
+							<MainFooter showDocs={false} />
 						</HelmetProvider>
 					</Page.Main>
 				</Page.Body>

--- a/packages/app-swap/src/Router.tsx
+++ b/packages/app-swap/src/Router.tsx
@@ -47,7 +47,6 @@ export const Router = () => (
 							helpPrompts: false,
 							share: false,
 							plugins: false,
-							docs: false,
 							syncAccounts: false,
 							sendModal: false,
 						}}
@@ -64,7 +63,7 @@ export const Router = () => (
 							<Route path="*" element={<Navigate to="/send" replace />} />
 						</Routes>
 					</ErrorBoundary>
-					<MainFooter />
+					<MainFooter showDocs={false} />
 				</HelmetProvider>
 			</Page.Main>
 		</Page.Body>

--- a/packages/app-validators/src/Headers.tsx
+++ b/packages/app-validators/src/Headers.tsx
@@ -16,7 +16,6 @@ const menuPopoverFeatures = {
 	helpPrompts: false,
 	share: false,
 	plugins: false,
-	docs: false,
 	syncAccounts: false,
 	sendModal: false,
 } satisfies MenuPopoverFeatureFlags

--- a/packages/app-validators/src/Router.tsx
+++ b/packages/app-validators/src/Router.tsx
@@ -105,7 +105,7 @@ const RouterInner = () => {
 									<Route path="*" element={<Navigate to="/" replace />} />
 								</Routes>
 							</ErrorBoundary>
-							<MainFooter />
+							<MainFooter showDocs={false} />
 						</HelmetProvider>
 					</Page.Main>
 				</Page.Body>

--- a/packages/ui-app/src/Headers/Popovers/MenuPopover/index.tsx
+++ b/packages/ui-app/src/Headers/Popovers/MenuPopover/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import {
-	faBookOpen,
 	faCloud,
 	faCog,
 	faDollarSign,
@@ -23,7 +22,7 @@ import { useOutsideAlerter } from '@w3ux/hooks'
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import DiscordSVG from 'assets/brands/discord.svg?react'
 import EnvelopeSVG from 'assets/icons/envelope.svg?react'
-import { PlatformDocsURL, PlatformName, PlatformURL } from 'consts'
+import { PlatformName, PlatformURL } from 'consts'
 import { getRelayChainData } from 'consts/util/chains'
 import { useBalances } from 'hooks/useBalances'
 import { useCurrency } from 'hooks/useCurrency'
@@ -53,7 +52,6 @@ export const MenuPopover = ({
 		helpPrompts: showHelpPrompts = true,
 		share: showShare = true,
 		plugins: showPlugins = true,
-		docs: showDocs = true,
 		syncAccounts: showSyncAccounts = true,
 	} = {},
 }: {
@@ -266,17 +264,6 @@ export const MenuPopover = ({
 					</div>
 				</button>
 			</MenuItem>
-			{showDocs && (
-				<DefaultButton
-					text={t('docs', { ns: 'app' })}
-					iconLeft={faBookOpen}
-					iconRight={faExternalLinkAlt}
-					onClick={() => {
-						setOpen(false)
-						window.open(`${PlatformDocsURL}/${i18n.language}`, '_blank')
-					}}
-				/>
-			)}
 			<DefaultButton
 				text={PlatformName}
 				iconLeft={faCloud}

--- a/packages/ui-app/src/Headers/Popovers/MenuPopover/index.tsx
+++ b/packages/ui-app/src/Headers/Popovers/MenuPopover/index.tsx
@@ -1,7 +1,6 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import {
 	faBookOpen,
 	faCloud,
@@ -24,12 +23,7 @@ import { useOutsideAlerter } from '@w3ux/hooks'
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import DiscordSVG from 'assets/brands/discord.svg?react'
 import EnvelopeSVG from 'assets/icons/envelope.svg?react'
-import {
-	PlatformDocsURL,
-	PlatformGitHubURL,
-	PlatformName,
-	PlatformURL,
-} from 'consts'
+import { PlatformDocsURL, PlatformName, PlatformURL } from 'consts'
 import { getRelayChainData } from 'consts/util/chains'
 import { useBalances } from 'hooks/useBalances'
 import { useCurrency } from 'hooks/useCurrency'
@@ -283,15 +277,6 @@ export const MenuPopover = ({
 					}}
 				/>
 			)}
-			<DefaultButton
-				text="GitHub"
-				iconLeft={faGithub}
-				iconRight={faExternalLinkAlt}
-				onClick={() => {
-					setOpen(false)
-					window.open(PlatformGitHubURL, '_blank')
-				}}
-			/>
 			<DefaultButton
 				text={PlatformName}
 				iconLeft={faCloud}

--- a/packages/ui-app/src/Headers/types.ts
+++ b/packages/ui-app/src/Headers/types.ts
@@ -9,7 +9,6 @@ export interface MenuPopoverFeatureFlags {
 	helpPrompts?: boolean
 	share?: boolean
 	plugins?: boolean
-	docs?: boolean
 	syncAccounts?: boolean
 	sendModal?: boolean
 }

--- a/packages/ui-app/src/MainFooter/index.tsx
+++ b/packages/ui-app/src/MainFooter/index.tsx
@@ -8,6 +8,7 @@ import CloudIconSVG from 'assets/icons/cloud.svg?react'
 import BigNumber from 'bignumber.js'
 import {
 	PlatformDisclaimerURL,
+	PlatformDocsURL,
 	PlatformGitHubURL,
 	PlatformName,
 	PlatformPrivacyURL,
@@ -22,8 +23,8 @@ import classes from './index.module.scss'
 import { Status } from './Status'
 import { TokenPrice } from './TokenPrice'
 
-export const MainFooter = () => {
-	const { t } = useTranslation('app')
+export const MainFooter = ({ showDocs = true }: { showDocs?: boolean }) => {
+	const { t, i18n } = useTranslation('app')
 	const { plugins } = usePlugins()
 
 	const [blockNumber, setBlockNumber] = useState<number>()
@@ -68,6 +69,17 @@ export const MainFooter = () => {
 								GitHub
 							</a>
 						</p>
+						{showDocs && (
+							<p>
+								<a
+									href={`${PlatformDocsURL}/${i18n.language}`}
+									target="_blank"
+									rel="noreferrer"
+								>
+									{t('docs')}
+								</a>
+							</p>
+						)}
 					</section>
 					<section>
 						<div className={classes.hideSmall}>

--- a/packages/ui-app/src/MainFooter/index.tsx
+++ b/packages/ui-app/src/MainFooter/index.tsx
@@ -8,6 +8,7 @@ import CloudIconSVG from 'assets/icons/cloud.svg?react'
 import BigNumber from 'bignumber.js'
 import {
 	PlatformDisclaimerURL,
+	PlatformGitHubURL,
 	PlatformName,
 	PlatformPrivacyURL,
 	PlatformURL,
@@ -39,17 +40,18 @@ export const MainFooter = () => {
 	return (
 		<Page.Footer>
 			<div className={`${classes.wrapper} pagePadding containerWidth`}>
-				<div className={classes.brand}>
+				<a
+					className={classes.brand}
+					href={PlatformURL}
+					target="_blank"
+					rel="noreferrer"
+					aria-label={PlatformName}
+				>
 					<CloudIconSVG className={classes.icon} />
 					<span className={classes.cloudLabel}>Cloud</span>
-				</div>
+				</a>
 				<div className={classes.summary}>
 					<section>
-						<p>
-							<a href={PlatformURL} target="_blank" rel="noreferrer">
-								{PlatformName}
-							</a>
-						</p>
 						<Status />
 						<p>
 							<a href={PlatformPrivacyURL} target="_blank" rel="noreferrer">
@@ -59,6 +61,11 @@ export const MainFooter = () => {
 						<p>
 							<a href={PlatformDisclaimerURL} target="_blank" rel="noreferrer">
 								{t('disclaimer')}
+							</a>
+						</p>
+						<p>
+							<a href={PlatformGitHubURL} target="_blank" rel="noreferrer">
+								GitHub
 							</a>
 						</p>
 					</section>


### PR DESCRIPTION
Simplify the header menu for end users by moving GitHub and Docs links to the footer in all builds.

- Place GitHub after Disclaimer, followed by Docs when `MainFooter.showDocs` is enabled. Preserve language-specific Docs URLs and existing per-app visibility settings.
- Make the footer logo and Cloud text link to the platform, replacing the separate platform text link.
- Remove the obsolete header `docs` feature flag and unused imports.

Validation: TypeScript checks pass for the shared UI package and all four apps; Biome and diff checks pass.