### PR TITLE
feat(refactor): Apply retainment schema updates

### DIFF
--- a/packages/app-staking/src/library/GenerateNominations/utils.ts
+++ b/packages/app-staking/src/library/GenerateNominations/utils.ts
@@ -10,7 +10,7 @@ export const getValidatorsWithRetainment = (
 	retainmentByAddress: ReadonlyMap<string, ValidatorRetainmentResult | null>,
 ) =>
 	validators.flatMap((validator) => {
-		const rate = retainmentByAddress.get(validator.address)?.months[0]
+		const rate = retainmentByAddress.get(validator.address)?.retainment.oneMonth
 			?.retainmentRate
 		return typeof rate === 'number' && Number.isFinite(rate)
 			? [{ rate: clampRate(rate), validator }]

--- a/packages/app-staking/src/library/StakingApiOperatorList/Item.tsx
+++ b/packages/app-staking/src/library/StakingApiOperatorList/Item.tsx
@@ -57,7 +57,7 @@ export const Item = ({ format, operator }: ItemProps) => {
 	)
 	const averageSelfStake =
 		validatorCount > 0 ? combinedSelfStake.dividedBy(validatorCount) : undefined
-	const suppliedRetainmentRate = operator.retainment?.retainmentRate
+	const suppliedRetainmentRate = operator.retainment.oneMonth?.retainmentRate
 	const retainmentRate =
 		typeof suppliedRetainmentRate === 'number' &&
 		Number.isFinite(suppliedRetainmentRate)
@@ -69,8 +69,8 @@ export const Item = ({ format, operator }: ItemProps) => {
 			: `${retainmentRate.toLocaleString(i18n.resolvedLanguage, {
 					maximumFractionDigits: 1,
 				})}%`
-	const retainmentMonthDate = operator.retainment
-		? new Date(operator.retainment.fromTimestamp * 1000)
+	const retainmentMonthDate = operator.retainment.oneMonth
+		? new Date(operator.retainment.oneMonth.fromTimestamp * 1000)
 		: undefined
 	const retainmentMonth = retainmentMonthDate
 		? new Intl.DateTimeFormat(i18n.resolvedLanguage, {

--- a/packages/app-staking/src/library/StakingApiValidatorList/Item.tsx
+++ b/packages/app-staking/src/library/StakingApiValidatorList/Item.tsx
@@ -79,7 +79,7 @@ export const Item = ({
 	const selfStakeMax = isMaxSelfStake(selfStakePlanck, hardCapSelfStake)
 	const rateAfterCommission = getRateAfterCommission(rate, prefs.commission)
 	const retainmentStats = useRetainmentStatsData({
-		period: validator.retainment ?? undefined,
+		period: validator.retainment.oneMonth ?? undefined,
 		selfStakeMax,
 		unit,
 		units,
@@ -101,7 +101,7 @@ export const Item = ({
 		prefs,
 		validatorStatus,
 	}
-	const retainmentHistoryDisabled = validator.retainment === null
+	const retainmentHistoryDisabled = validator.retainment.oneMonth === null
 	const openRetainmentHistory = () =>
 		openModal({
 			key: 'RetainmentHistory',

--- a/packages/plugin-staking-api/src/queries/fragments/retainment.ts
+++ b/packages/plugin-staking-api/src/queries/fragments/retainment.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql } from '@apollo/client'
+
+export const VALIDATOR_RETAINMENT_FIELDS = gql`
+  fragment ValidatorRetainmentWindowFields on ValidatorRetainmentWindow {
+    month
+    year
+    windowMonths
+    includedMonthCount
+    fromEra
+    toEra
+    fromTimestamp
+    toTimestamp
+    graphRewards
+    netInflow
+    retained
+    retainmentRate
+    validatorRewards
+    selfStakeChange
+    compounded
+    compoundRate
+  }
+
+  fragment ValidatorRetainmentFields on ValidatorRetainment {
+    oneMonth { ...ValidatorRetainmentWindowFields }
+    threeMonths { ...ValidatorRetainmentWindowFields }
+  }
+`
+
+export const OPERATOR_RETAINMENT_FIELDS = gql`
+  fragment OperatorRetainmentWindowFields on OperatorRetainmentWindow {
+    month
+    year
+    windowMonths
+    includedMonthCount
+    fromEra
+    toEra
+    fromTimestamp
+    toTimestamp
+    graphRewards
+    netInflow
+    retained
+    retainmentRate
+  }
+
+  fragment OperatorRetainmentFields on OperatorRetainment {
+    oneMonth { ...OperatorRetainmentWindowFields }
+    threeMonths { ...OperatorRetainmentWindowFields }
+  }
+`

--- a/packages/plugin-staking-api/src/queries/operatorList.ts
+++ b/packages/plugin-staking-api/src/queries/operatorList.ts
@@ -7,9 +7,11 @@ import type {
 	OperatorListVariables,
 	QueryReturn,
 } from '../types'
+import { OPERATOR_RETAINMENT_FIELDS } from './fragments/retainment'
 import { useApiQuery } from './generic'
 
 const QUERY = gql`
+  ${OPERATOR_RETAINMENT_FIELDS}
   query OperatorList(
     $network: String!
     $page: Int
@@ -33,10 +35,7 @@ const QUERY = gql`
         validatorCount
         activeValidatorCount
         combinedSelfStake
-        retainment {
-          fromTimestamp
-          retainmentRate
-        }
+        retainment { ...OperatorRetainmentFields }
       }
       page
       pageSize

--- a/packages/plugin-staking-api/src/queries/validatorDetailsBatch.ts
+++ b/packages/plugin-staking-api/src/queries/validatorDetailsBatch.ts
@@ -3,9 +3,11 @@
 
 import { gql } from '@apollo/client'
 import type { ValidatorDetailsBatchData } from '../types'
+import { VALIDATOR_RETAINMENT_FIELDS } from './fragments/retainment'
 import { fetchQuery } from './generic'
 
 const QUERY = gql`
+  ${VALIDATOR_RETAINMENT_FIELDS}
   query ValidatorDetailsBatch(
     $network: String!
     $validators: [String!]!
@@ -16,13 +18,8 @@ const QUERY = gql`
     validatorRetainmentBatch(network: $network, validators: $validators) {
       validator
       result {
-        months {
-          fromTimestamp
-          netInflow
-          retainmentRate
-          selfStakeChange
-          compoundRate
-        }
+        months { ...ValidatorRetainmentWindowFields }
+        retainment { ...ValidatorRetainmentFields }
       }
     }
     validatorAvgRewardRateBatch(

--- a/packages/plugin-staking-api/src/queries/validatorList.ts
+++ b/packages/plugin-staking-api/src/queries/validatorList.ts
@@ -7,9 +7,11 @@ import type {
 	ValidatorListData,
 	ValidatorListVariables,
 } from '../types'
+import { VALIDATOR_RETAINMENT_FIELDS } from './fragments/retainment'
 import { useApiQuery } from './generic'
 
 const QUERY = gql`
+  ${VALIDATOR_RETAINMENT_FIELDS}
   query ValidatorList(
     $network: String!
     $page: Int
@@ -39,13 +41,7 @@ const QUERY = gql`
         selfStake
         totalStake
         activityRank
-        retainment {
-          fromTimestamp
-          netInflow
-          retainmentRate
-          selfStakeChange
-          compoundRate
-        }
+        retainment { ...ValidatorRetainmentFields }
       }
       page
       pageSize

--- a/packages/plugin-staking-api/src/queries/validatorRetainment.ts
+++ b/packages/plugin-staking-api/src/queries/validatorRetainment.ts
@@ -3,18 +3,15 @@
 
 import { gql } from '@apollo/client'
 import type { QueryReturn, ValidatorRetainmentData } from '../types'
+import { VALIDATOR_RETAINMENT_FIELDS } from './fragments/retainment'
 import { useApiQuery } from './generic'
 
 const QUERY = gql`
+  ${VALIDATOR_RETAINMENT_FIELDS}
   query ValidatorRetainment($network: String!, $validator: String!) {
     validatorRetainment(network: $network, validator: $validator) {
-      months {
-        fromTimestamp
-        netInflow
-        retainmentRate
-        selfStakeChange
-        compoundRate
-      }
+      months { ...ValidatorRetainmentWindowFields }
+      retainment { ...ValidatorRetainmentFields }
     }
   }
 `

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -85,7 +85,7 @@ export interface ValidatorListItem {
 	selfStake: string | null
 	totalStake: string | null
 	activityRank: number | null
-	retainment: ValidatorRetainmentPeriod | null
+	retainment: ValidatorRetainment
 }
 
 export type OperatorListOrder =
@@ -129,12 +129,7 @@ export interface OperatorListItem {
 	validatorCount: number
 	activeValidatorCount: number
 	combinedSelfStake: string
-	retainment: OperatorRetainmentPeriod | null
-}
-
-export interface OperatorRetainmentPeriod {
-	fromTimestamp: number
-	retainmentRate: number | null
+	retainment: OperatorRetainment
 }
 
 export interface OperatorStatsVariables extends Record<string, unknown> {
@@ -328,20 +323,44 @@ export interface ValidatorRetainmentBatch {
 }
 
 export interface ValidatorRetainmentResult {
-	months: ValidatorRetainmentPeriod[]
+	months: ValidatorRetainmentWindow[]
+	retainment: ValidatorRetainment
 }
 
 export interface ValidatorRetainmentData {
 	validatorRetainment: ValidatorRetainmentResult | null
 }
 
-export interface ValidatorRetainmentPeriod {
-	fromTimestamp: number
-	netInflow: string
-	retainmentRate: number | null
-	selfStakeChange: string
-	compoundRate: number
+export interface RetainmentWindows<Window> {
+	oneMonth: Window | null
+	threeMonths: Window | null
 }
+
+export interface GraphRetainmentWindow {
+	month: number
+	year: number
+	windowMonths: number
+	includedMonthCount: number
+	fromEra: number
+	toEra: number
+	fromTimestamp: number
+	toTimestamp: number
+	graphRewards: string
+	netInflow: string
+	retained: string
+	retainmentRate: number | null
+}
+
+export interface ValidatorRetainmentWindow extends GraphRetainmentWindow {
+	validatorRewards: string
+	selfStakeChange: string
+	compounded: string
+	compoundRate: number | null
+}
+
+export type OperatorRetainmentWindow = GraphRetainmentWindow
+export type ValidatorRetainment = RetainmentWindows<ValidatorRetainmentWindow>
+export type OperatorRetainment = RetainmentWindows<OperatorRetainmentWindow>
 
 export interface ValidatorDetailsBatchData
 	extends ValidatorAvgRewardRateBatchData,

--- a/packages/tests/src/retainment.test.ts
+++ b/packages/tests/src/retainment.test.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { expect, test, vi } from 'vitest'
+import { getValidatorsWithRetainment } from '../../app-staking/src/library/GenerateNominations/utils'
+import type {
+	ValidatorRetainmentResult,
+	ValidatorRetainmentWindow,
+} from '../../plugin-staking-api/src/types'
+import { useRetainmentStatsData } from '../../ui-app/src/RetainmentStats/useRetainmentStatsData'
+
+vi.mock('../../ui-app/node_modules/react-i18next/dist/es/index.js', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+		i18n: { resolvedLanguage: 'en' },
+	}),
+}))
+
+const window = (
+	overrides: Partial<ValidatorRetainmentWindow> = {},
+): ValidatorRetainmentWindow => ({
+	month: 8,
+	year: 2026,
+	windowMonths: 1,
+	includedMonthCount: 1,
+	fromEra: 100,
+	toEra: 130,
+	fromTimestamp: 1785542400,
+	toTimestamp: 1788220800,
+	graphRewards: '100000000000000000000',
+	netInflow: '-900719925474099312345',
+	retained: '75000000000000000000',
+	retainmentRate: 75,
+	validatorRewards: '0',
+	selfStakeChange: '0',
+	compounded: '0',
+	compoundRate: null,
+	...overrides,
+})
+
+const result = (
+	oneMonth: ValidatorRetainmentWindow | null,
+	threeMonths: ValidatorRetainmentWindow | null = null,
+): ValidatorRetainmentResult => ({
+	months: oneMonth ? [oneMonth] : [],
+	retainment: { oneMonth, threeMonths },
+})
+
+test('nomination scoring uses the latest month and never substitutes rolling or missing rates', () => {
+	const results = new Map<string, ValidatorRetainmentResult | null>([
+		[
+			'complete',
+			result(
+				window(),
+				window({ windowMonths: 3, includedMonthCount: 2, retainmentRate: 10 }),
+			),
+		],
+		['monthly', result(window({ retainmentRate: 25 }))],
+		['rolling', result(null, window({ windowMonths: 3, retainmentRate: 100 }))],
+		['empty', result(null)],
+		['null', null],
+		[
+			'zeroRewards',
+			result(window({ graphRewards: '0', retainmentRate: null })),
+		],
+		['zeroRate', result(window({ retainmentRate: 0 }))],
+	])
+	const validators = [...results.keys(), 'missing'].map((address) => ({
+		address,
+		prefs: { commission: 0, blocked: false },
+	}))
+	expect(
+		getValidatorsWithRetainment(validators, results).map(
+			({ validator, rate }) => [validator.address, rate],
+		),
+	).toEqual([
+		['complete', 75],
+		['monthly', 25],
+		['zeroRate', 0],
+	])
+})
+
+test('monthly stats preserve unavailable rates, real zero rates and timestamps in seconds', () => {
+	const period = window({ retainmentRate: null })
+	const stats = useRetainmentStatsData({
+		period,
+		selfStakeMax: false,
+		unit: 'DOT',
+		units: 10,
+	})
+	expect(stats.compoundRate.value).toBeUndefined()
+	expect(stats.retainmentRate.value).toBeUndefined()
+	expect(stats.compoundRate.valueText).toBe('—')
+	expect(stats.month?.date.toISOString()).toBe('2026-08-01T00:00:00.000Z')
+	expect(stats.month?.label).toBe('August 2026')
+	expect(stats.netOutflow.prefix).toBe('−')
+	expect(period.netInflow).toBe('-900719925474099312345')
+	const zero = useRetainmentStatsData({
+		period: window({ compoundRate: 0, retainmentRate: 0 }),
+		selfStakeMax: false,
+		unit: 'DOT',
+		units: 10,
+	})
+	expect(zero.compoundRate.value).toBe(0)
+	expect(zero.retainmentRate.valueText).toBe('0%')
+})

--- a/packages/ui-app/src/RetainmentStats/useRetainmentStatsData.ts
+++ b/packages/ui-app/src/RetainmentStats/useRetainmentStatsData.ts
@@ -18,7 +18,7 @@ import {
 } from 'utils'
 
 export interface RetainmentPeriodData {
-	compoundRate: number
+	compoundRate: number | null
 	fromTimestamp: number
 	netInflow: string
 	retainmentRate: number | null

--- a/packages/ui-modals/src/RetainmentHistory/index.tsx
+++ b/packages/ui-modals/src/RetainmentHistory/index.tsx
@@ -5,7 +5,7 @@ import { Polkicon } from '@w3ux/react-polkicon'
 import { ellipsisFn } from '@w3ux/utils'
 import { useNetwork } from 'hooks/useNetwork'
 import { useValidatorRetainment } from 'plugin-staking-api'
-import type { ValidatorRetainmentPeriod } from 'plugin-staking-api/types'
+import type { ValidatorRetainmentWindow } from 'plugin-staking-api/types'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ModalTitle } from 'ui-app/ModalTitle'
@@ -16,7 +16,7 @@ import { getRetainmentStatus } from 'utils'
 import classes from './index.module.scss'
 
 export interface RetainmentHistoryOptions {
-	periods?: ValidatorRetainmentPeriod[]
+	periods?: ValidatorRetainmentWindow[]
 	selfStakeMax: boolean
 	unit: string
 	units: number
@@ -27,19 +27,19 @@ export interface RetainmentHistoryOptions {
 interface RetainmentPeriodProps {
 	current?: boolean
 	isPreloading?: boolean
-	period?: ValidatorRetainmentPeriod
+	period?: ValidatorRetainmentWindow
 	selfStakeMax: boolean
 	unit: string
 	units: number
 }
 
-const hasRetainmentStats = (period: ValidatorRetainmentPeriod) =>
+const hasRetainmentStats = (period: ValidatorRetainmentWindow) =>
 	period.retainmentRate !== null ||
-	period.compoundRate !== 0 ||
+	(typeof period.compoundRate === 'number' && period.compoundRate !== 0) ||
 	Number(period.netInflow) !== 0 ||
 	Number(period.selfStakeChange) !== 0
 
-const trimTrailingEmptyPeriods = (periods: ValidatorRetainmentPeriod[]) => {
+const trimTrailingEmptyPeriods = (periods: ValidatorRetainmentWindow[]) => {
 	let historyEnd = periods.length
 
 	while (historyEnd > 0 && !hasRetainmentStats(periods[historyEnd - 1])) {
@@ -53,8 +53,8 @@ const getMonthIndex = (date: Date) =>
 	date.getUTCFullYear() * 12 + date.getUTCMonth()
 
 const getMissingMonthDates = (
-	newerPeriod: ValidatorRetainmentPeriod,
-	olderPeriod: ValidatorRetainmentPeriod,
+	newerPeriod: ValidatorRetainmentWindow,
+	olderPeriod: ValidatorRetainmentWindow,
 ) => {
 	const newerMonth = getMonthIndex(new Date(newerPeriod.fromTimestamp * 1000))
 	const olderMonth = getMonthIndex(new Date(olderPeriod.fromTimestamp * 1000))
@@ -66,7 +66,7 @@ const getMissingMonthDates = (
 	})
 }
 
-const getPeriodStatus = (period: ValidatorRetainmentPeriod) =>
+const getPeriodStatus = (period: ValidatorRetainmentWindow) =>
 	typeof period.retainmentRate === 'number' &&
 	Number.isFinite(period.retainmentRate)
 		? getRetainmentStatus(period.retainmentRate)


### PR DESCRIPTION
Updates the staking API client for the new retainment schema, which exposes nullable `oneMonth` and `threeMonths` windows. Validator/operator list stats and nomination health scoring continue to use the one-month window, while monthly history remains available through `months`.

- Add shared GraphQL fragments and matching window types across validator/operator lists, validator history, and batch detail queries, including window metadata, reward amounts, and nullable rates.
- Read list stats and nomination scores from `retainment.oneMonth`, preserving unavailable rates separately from real zero values and excluding missing monthly rates from scoring.
- Support nullable compound rates in shared stats and avoid treating a null compound rate as activity when trimming empty history periods.
- Add regression coverage for monthly versus rolling windows, missing/null/zero rates, timestamp conversion, and signed amount handling.

Validation at `5fd9767`:

- `pnpm check` and `pnpm license:headers` passed.
- `pnpm test`: 67 tests passed across 10 files.
- `build:verify` passed for staking, nominate, validators, and swap (TypeScript checks and Vite builds).
- Locale validation passed.
- All four changed GraphQL queries validated against the local staking API schema; deployed API behavior was not smoke-tested.

Review sweep found no blocking issues. Builds emitted chunk-size and plugin-timing warnings. GitHub's license check passed; its verification job was still running when this description was added.
