### PR TITLE
refactor: Load nomination status from staking API

### DIFF
--- a/packages/app-staking/src/canvas/Pool/Nominations/index.tsx
+++ b/packages/app-staking/src/canvas/Pool/Nominations/index.tsx
@@ -3,6 +3,7 @@
 
 import { useBondedPools } from 'contexts/Pools/BondedPools'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { NominationList } from 'library/NominationList'
 import { useTranslation } from 'react-i18next'
 import { Subheading } from 'ui-core/canvas'
@@ -11,14 +12,15 @@ import { NominationsWrapper } from '../Wrappers'
 
 export const Nominations = ({ stash, poolId }: NominationsProps) => {
 	const { t } = useTranslation()
-	const { getValidators } = useValidators()
+	const { getValidators, formatWithPrefs } = useValidators()
+	const retainmentStatsEnabled = useRetainmentStatsEnabled()
 	const { poolsNominations } = useBondedPools()
 
 	// Extract validator entries from pool targets.
 	const targets = poolsNominations[poolId]?.targets || []
-	const filteredTargets = getValidators().filter(({ address }) =>
-		targets.includes(address),
-	)
+	const filteredTargets = retainmentStatsEnabled
+		? formatWithPrefs(targets)
+		: getValidators().filter(({ address }) => targets.includes(address))
 
 	return (
 		<NominationsWrapper>

--- a/packages/app-staking/src/library/ListItem/Labels/NominationStatus.tsx
+++ b/packages/app-staking/src/library/ListItem/Labels/NominationStatus.tsx
@@ -14,7 +14,10 @@ import type { NominationStatusProps } from '../types'
 type NominationStatusDataProps = Pick<
 	NominationStatusProps,
 	'address' | 'asIncoming' | 'bondFor' | 'nominator' | 'status'
->
+> & {
+	activeBacking?: string
+	isPreloading?: boolean
+}
 
 export const useNominationStatusData = ({
 	address,
@@ -22,6 +25,8 @@ export const useNominationStatusData = ({
 	bondFor,
 	asIncoming = false,
 	status,
+	activeBacking,
+	isPreloading = false,
 }: NominationStatusDataProps) => {
 	const { t, i18n } = useTranslation('app')
 	const { network } = useNetwork()
@@ -29,16 +34,23 @@ export const useNominationStatusData = ({
 		getActiveValidator,
 		eraStakers: { activeAccountOwnStake },
 	} = useEraStakers()
-	const { syncing } = useSyncing(['era-stakers'])
+	const { syncing: eraStakersSyncing } = useSyncing(['era-stakers'])
+
 	const { unit, units } = getStakingChainData(network)
 
-	let stakedAmount = new BigNumber(0)
-	if (bondFor === 'nominator') {
+	// Determine if the component should be in a syncing state based on the availability of
+	// activeBacking and preloading status
+	const syncing = activeBacking !== undefined ? isPreloading : eraStakersSyncing
+
+	let totalActiveBacking = new BigNumber(0)
+	if (activeBacking !== undefined) {
+		totalActiveBacking = planckToUnitBn(new BigNumber(activeBacking), units)
+	} else if (bondFor === 'nominator') {
 		if (status === 'active') {
 			const backing = getActiveValidator(address)?.others.find(
 				({ who }) => who === nominator,
 			)
-			stakedAmount = backing
+			totalActiveBacking = backing
 				? planckToUnitBn(new BigNumber(backing.value), units)
 				: new BigNumber(
 						activeAccountOwnStake?.find((own) => own.address === address)
@@ -49,7 +61,7 @@ export const useNominationStatusData = ({
 		const staker = getActiveValidator(address)
 		const exists = (staker?.others || []).find(({ who }) => who === nominator)
 		if (exists) {
-			stakedAmount = planckToUnitBn(new BigNumber(exists.value), units)
+			totalActiveBacking = planckToUnitBn(new BigNumber(exists.value), units)
 		}
 	}
 
@@ -68,13 +80,13 @@ export const useNominationStatusData = ({
 
 	return {
 		label: t(statusTKey),
-		stakedAmount,
+		totalActiveBacking,
 		syncing,
 		unit,
-		value: stakedAmount.isGreaterThan(0)
+		value: totalActiveBacking.isGreaterThan(0)
 			? syncing
 				? '...'
-				: `${formatCompactNumber(stakedAmount.toNumber(), i18n.resolvedLanguage)} ${unit}`
+				: `${formatCompactNumber(totalActiveBacking.toNumber(), i18n.resolvedLanguage)} ${unit}`
 			: undefined,
 	}
 }

--- a/packages/app-staking/src/library/NominationList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/NominationList/DetailedItem.tsx
@@ -36,6 +36,8 @@ export const DetailedItem = ({
 	displayFor,
 	format,
 	nominationStatus = 'waiting',
+	activeBacking,
+	isNominationPreloading,
 	eraPoints,
 	rate,
 	retainment,
@@ -49,13 +51,15 @@ export const DetailedItem = ({
 	const { selfStake, selfStakeMax } = useValidatorSelfStake(address, units)
 	const {
 		label: statusLabel,
-		stakedAmount: backingStake,
+		totalActiveBacking,
 		syncing: backingStakePreloading,
 	} = useNominationStatusData({
 		address,
 		bondFor,
 		nominator,
 		status: nominationStatus,
+		activeBacking,
+		isPreloading: isNominationPreloading,
 	})
 	const {
 		period,
@@ -119,7 +123,7 @@ export const DetailedItem = ({
 				selfStakeMax={selfStakeMax}
 				statusActive={nominationStatus === 'active'}
 				statusLabel={statusLabel}
-				statusValue={backingStake}
+				statusValue={totalActiveBacking}
 				unit={unit}
 				validator={validator}
 			/>
@@ -181,7 +185,7 @@ export const DetailedItem = ({
 					status={validatorStatus}
 					statusActive={nominationStatus === 'active'}
 					statusLabel={statusLabel}
-					statusValue={backingStake}
+					statusValue={totalActiveBacking}
 					unit={unit}
 				/>
 			}

--- a/packages/app-staking/src/library/NominationList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/NominationList/DetailedItem.tsx
@@ -35,8 +35,7 @@ export const DetailedItem = ({
 	bondFor,
 	displayFor,
 	format,
-	nominationStatus = 'waiting',
-	activeBacking,
+	apiNominee,
 	isNominationPreloading,
 	eraPoints,
 	rate,
@@ -49,6 +48,10 @@ export const DetailedItem = ({
 	const { address, prefs, validatorStatus } = validator
 	const { unit, units } = getStakingChainData(network)
 	const { selfStake, selfStakeMax } = useValidatorSelfStake(address, units)
+	const nominationStatus =
+		apiNominee?.status === 'active' || apiNominee?.status === 'inactive'
+			? apiNominee.status
+			: 'waiting'
 	const {
 		label: statusLabel,
 		totalActiveBacking,
@@ -58,7 +61,7 @@ export const DetailedItem = ({
 		bondFor,
 		nominator,
 		status: nominationStatus,
-		activeBacking,
+		activeBacking: apiNominee?.activeBacking ?? '0',
 		isPreloading: isNominationPreloading,
 	})
 	const {

--- a/packages/app-staking/src/library/NominationList/index.tsx
+++ b/packages/app-staking/src/library/NominationList/index.tsx
@@ -16,7 +16,10 @@ import { FilterHeaderWrapper, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer, MotionItem } from 'library/List/MotionContainer'
 import { EMPTY_ERA_POINTS } from 'library/List/Utils'
 import { useForceCardLayout } from 'library/List/useForceCardLayout'
-import { fetchValidatorDetailsBatch } from 'plugin-staking-api'
+import {
+	fetchValidatorDetailsBatch,
+	useStakerWithNominees,
+} from 'plugin-staking-api'
 import type { ValidatorDetailsBatchData } from 'plugin-staking-api/types'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -118,6 +121,29 @@ export const NominationListInner = ({
 		() => validators.map(({ address }) => address),
 		[validators],
 	)
+	const { data: nominationData, loading: nominationsPreloading } =
+		useStakerWithNominees(
+			{
+				network,
+				era: activeEra.index,
+				who: nominator ?? '',
+				addresses: initialValidators.map(({ address }) => address),
+			},
+			{
+				skip:
+					!retainmentStatsEnabled ||
+					activeEra.index === 0 ||
+					!nominator ||
+					initialValidators.length === 0,
+			},
+		)
+	const getApiNominationStatus = (address: string): NominationStatus => {
+		const status = nominationData.getNomineesStatus.statuses.find(
+			(nominee) => nominee.address === address,
+		)?.status
+		return status === 'active' || status === 'inactive' ? status : 'waiting'
+	}
+
 	const pageKey = useMemo(
 		() => JSON.stringify(addresses.map((address, i) => `${i}${address}`)),
 		[addresses],
@@ -267,7 +293,21 @@ export const NominationListInner = ({
 											: rates[pageKey]?.[validator.address]
 									}
 									retainment={retainmentByAddress.get(validator.address)}
-									nominationStatus={nominationStatus.current[validator.address]}
+									nominationStatus={
+										retainmentStatsEnabled
+											? getApiNominationStatus(validator.address)
+											: nominationStatus.current[validator.address]
+									}
+									activeBacking={
+										retainmentStatsEnabled
+											? (nominationData.getNomineesStatus.statuses.find(
+													({ address }) => address === validator.address,
+												)?.activeBacking ?? '0')
+											: undefined
+									}
+									isNominationPreloading={
+										retainmentStatsEnabled && nominationsPreloading
+									}
 								/>
 							</MotionItem>
 						))

--- a/packages/app-staking/src/library/NominationList/index.tsx
+++ b/packages/app-staking/src/library/NominationList/index.tsx
@@ -121,6 +121,7 @@ export const NominationListInner = ({
 		() => validators.map(({ address }) => address),
 		[validators],
 	)
+	// Request known nomination targets without waiting for validator entries or exposures.
 	const { data: nominationData, loading: nominationsPreloading } =
 		useStakerWithNominees(
 			{
@@ -137,13 +138,6 @@ export const NominationListInner = ({
 					initialValidators.length === 0,
 			},
 		)
-	const getApiNominationStatus = (address: string): NominationStatus => {
-		const status = nominationData.getNomineesStatus.statuses.find(
-			(nominee) => nominee.address === address,
-		)?.status
-		return status === 'active' || status === 'inactive' ? status : 'waiting'
-	}
-
 	const pageKey = useMemo(
 		() => JSON.stringify(addresses.map((address, i) => `${i}${address}`)),
 		[addresses],
@@ -293,21 +287,11 @@ export const NominationListInner = ({
 											: rates[pageKey]?.[validator.address]
 									}
 									retainment={retainmentByAddress.get(validator.address)}
-									nominationStatus={
-										retainmentStatsEnabled
-											? getApiNominationStatus(validator.address)
-											: nominationStatus.current[validator.address]
-									}
-									activeBacking={
-										retainmentStatsEnabled
-											? (nominationData.getNomineesStatus.statuses.find(
-													({ address }) => address === validator.address,
-												)?.activeBacking ?? '0')
-											: undefined
-									}
-									isNominationPreloading={
-										retainmentStatsEnabled && nominationsPreloading
-									}
+									nominationStatus={nominationStatus.current[validator.address]}
+									apiNominee={nominationData.getNomineesStatus.statuses.find(
+										({ address }) => address === validator.address,
+									)}
+									isNominationPreloading={nominationsPreloading}
 								/>
 							</MotionItem>
 						))

--- a/packages/app-staking/src/library/NominationList/types.ts
+++ b/packages/app-staking/src/library/NominationList/types.ts
@@ -4,6 +4,7 @@
 import type { ListFormat } from 'contexts/List/types'
 import type { ValidatorListEntry } from 'contexts/Validators/types'
 import type {
+	NomineeStatusEntry,
 	ValidatorEraPoints,
 	ValidatorRetainmentResult,
 } from 'plugin-staking-api/types'
@@ -34,7 +35,7 @@ export interface ItemProps {
 	format: ListFormat
 	toggleFavorites?: boolean
 	nominationStatus?: NominationStatus
-	activeBacking?: string
+	apiNominee?: NomineeStatusEntry
 	isNominationPreloading?: boolean
 	eraPoints: ValidatorEraPoints[]
 	isPreloading?: boolean

--- a/packages/app-staking/src/library/NominationList/types.ts
+++ b/packages/app-staking/src/library/NominationList/types.ts
@@ -34,6 +34,8 @@ export interface ItemProps {
 	format: ListFormat
 	toggleFavorites?: boolean
 	nominationStatus?: NominationStatus
+	activeBacking?: string
+	isNominationPreloading?: boolean
 	eraPoints: ValidatorEraPoints[]
 	isPreloading?: boolean
 	rate?: number

--- a/packages/app-staking/src/library/Nominations/index.tsx
+++ b/packages/app-staking/src/library/Nominations/index.tsx
@@ -7,6 +7,7 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useActivePool } from 'hooks/useActivePool'
 import { useBalances } from 'hooks/useBalances'
 import { useHelp } from 'hooks/useHelp'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { useStaking } from 'hooks/useStaking'
 import { useSyncing } from 'hooks/useSyncing'
 import { ListStatusHeader } from 'library/List'
@@ -42,6 +43,7 @@ export const Nominations = ({
 	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { syncing } = useSyncing(['era-stakers'])
+	const retainmentStatsEnabled = useRetainmentStatsEnabled()
 	const { isReadOnlyAccount } = useImportedAccounts()
 
 	// Determine if pool or nominator.
@@ -130,7 +132,7 @@ export const Nominations = ({
 					</ButtonRow>
 				)}
 			</CardHeader>
-			{!isPool && syncing ? (
+			{!isPool && syncing && !retainmentStatsEnabled ? (
 				<ListStatusHeader>{`${t('syncing')}...`}</ListStatusHeader>
 			) : !nominator ? (
 				<ListStatusHeader>{t('notNominating')}.</ListStatusHeader>

--- a/packages/plugin-staking-api/src/queries/getStakerWithNominees.ts
+++ b/packages/plugin-staking-api/src/queries/getStakerWithNominees.ts
@@ -6,7 +6,7 @@ import type {
 	ActiveStatusWithNominees,
 	GetActiveStakerWithNomineesData,
 } from '../types'
-import { fetchQuery } from './generic'
+import { fetchQuery, useApiQuery } from './generic'
 
 const QUERY = gql`
   query GetStakerWithNominees($network: String!, $era: Int!, $who: String!, $addresses: [String!]!) {
@@ -14,6 +14,7 @@ const QUERY = gql`
     statuses {
       address
       status
+      activeBacking
     }
   }
   isActiveStaker(network: $network, address: $who) {
@@ -26,6 +27,17 @@ const DEFAULT_DATA: GetActiveStakerWithNomineesData = {
 	isActiveStaker: { active: false },
 	getNomineesStatus: { statuses: [] },
 }
+
+export const useStakerWithNominees = (
+	variables: { network: string; era: number; who: string; addresses: string[] },
+	options?: { skip?: boolean },
+) =>
+	useApiQuery<GetActiveStakerWithNomineesData>(
+		QUERY,
+		variables,
+		DEFAULT_DATA,
+		options,
+	)
 
 export const fetchGetStakerWithNominees = async (
 	network: string,

--- a/packages/plugin-staking-api/src/types.ts
+++ b/packages/plugin-staking-api/src/types.ts
@@ -478,18 +478,19 @@ export interface GetActiveStakerWithNomineesData {
 		active: boolean
 	}
 	getNomineesStatus: {
-		statuses: {
-			address: string
-			status: string
-		}[]
+		statuses: NomineeStatusEntry[]
 	}
 }
 export interface ActiveStatusWithNominees {
 	active: boolean
-	statuses: {
-		address: string
-		status: string
-	}[]
+	statuses: NomineeStatusEntry[]
+}
+
+export interface NomineeStatusEntry {
+	address: string
+	status: string
+	// The supplied nominator's active stake backing this validator, in planck.
+	activeBacking: string
 }
 
 export type StakerNominationStatus = 'active' | 'inactive' | 'waiting'

--- a/packages/tests/src/nomineeStake.test.ts
+++ b/packages/tests/src/nomineeStake.test.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { afterEach, expect, test, vi } from 'vitest'
+import { useNominationStatusData } from '../../app-staking/src/library/ListItem/Labels/NominationStatus'
+import { fetchGetStakerWithNominees } from '../../plugin-staking-api/src/queries/getStakerWithNominees'
+
+const { query, getActiveValidator, syncing } = vi.hoisted(() => ({
+	query: vi.fn(),
+	getActiveValidator: vi.fn(),
+	syncing: { value: true },
+}))
+
+vi.mock('../../plugin-staking-api/src/Client', () => ({ client: { query } }))
+vi.mock('contexts/EraStakers', () => ({
+	useEraStakers: () => ({
+		getActiveValidator,
+		eraStakers: { activeAccountOwnStake: [] },
+	}),
+}))
+vi.mock('../../hooks/src/useNetwork', () => ({
+	useNetwork: () => ({ network: 'polkadot' }),
+}))
+vi.mock('../../consts/src/util', () => ({
+	getStakingChainData: () => ({ unit: 'DOT', units: 10 }),
+}))
+vi.mock('../../hooks/src/useSyncing', () => ({
+	useSyncing: () => ({ syncing: syncing.value }),
+}))
+vi.mock('library/BondStatus', () => ({ BondStatus: () => null }))
+vi.mock(
+	'../../app-staking/node_modules/react-i18next/dist/es/index.js',
+	() => ({
+		useTranslation: () => ({
+			t: (key: string) => key,
+			i18n: { resolvedLanguage: 'en' },
+		}),
+	}),
+)
+
+afterEach(() => {
+	vi.resetAllMocks()
+	syncing.value = true
+})
+
+test('the nominee query requests backing stake and preserves planck precision per validator', async () => {
+	const statuses = [
+		{
+			address: 'active',
+			status: 'active',
+			activeBacking: '12345678901234567890',
+		},
+		{ address: 'inactive', status: 'inactive', activeBacking: '0' },
+		{ address: 'waiting', status: 'waiting', activeBacking: '0' },
+		{ address: 'invalid', status: 'invalid', activeBacking: '0' },
+	]
+	query.mockResolvedValue({
+		data: { isActiveStaker: { active: true }, getNomineesStatus: { statuses } },
+	})
+	expect(
+		await fetchGetStakerWithNominees(
+			'polkadot',
+			100,
+			'nominator',
+			statuses.map(({ address }) => address),
+		),
+	).toEqual({ active: true, statuses })
+	const request = query.mock.calls[0][0]
+	expect(request.query.loc.source.body).toMatch(
+		/statuses\s*\{\s*address\s*status\s*activeBacking\s*\}/,
+	)
+	expect(request.variables).toEqual({
+		network: 'polkadot',
+		era: 100,
+		who: 'nominator',
+		addresses: statuses.map(({ address }) => address),
+	})
+})
+
+test('an unavailable API returns the existing empty fallback', async () => {
+	query.mockRejectedValue(new Error('unavailable'))
+	expect(
+		await fetchGetStakerWithNominees('polkadot', 100, 'nominator', [
+			'validator',
+		]),
+	).toEqual({
+		active: false,
+		statuses: [],
+	})
+})
+
+test.each(['nominator', 'pool'] as const)(
+	'%s summaries use API stake while node exposures are still syncing',
+	(bondFor) => {
+		const result = useNominationStatusData({
+			address: 'validator',
+			nominator: 'stash',
+			bondFor,
+			status: 'active',
+			activeBacking: '12345678901234567890',
+		})
+		expect(result.totalActiveBacking.toFixed()).toBe('1234567890.123456789')
+		expect(result.label).toBe('backing')
+		expect(result.syncing).toBe(false)
+		expect(result.value).not.toBe('...')
+		expect(getActiveValidator).not.toHaveBeenCalled()
+	},
+)
+
+test('API loading and zero stake do not fall back to node exposures', () => {
+	const props = {
+		address: 'validator',
+		nominator: 'stash',
+		bondFor: 'nominator' as const,
+		status: 'inactive' as const,
+		activeBacking: '0',
+	}
+	const loading = useNominationStatusData({ ...props, isPreloading: true })
+	expect(loading.syncing).toBe(true)
+	const ready = useNominationStatusData(props)
+	expect(ready.syncing).toBe(false)
+	expect(ready.totalActiveBacking.isZero()).toBe(true)
+	expect(ready.label).toBe('notBacking')
+	expect(ready.value).toBeUndefined()
+	expect(getActiveValidator).not.toHaveBeenCalled()
+})
+
+test.each(['nominator', 'pool'] as const)(
+	'%s summaries retain node-backed amounts and loading without an API override',
+	(bondFor) => {
+		getActiveValidator.mockReturnValue({
+			others: [{ who: 'stash', value: '25000000000' }],
+		})
+		const result = useNominationStatusData({
+			address: 'validator',
+			nominator: 'stash',
+			bondFor,
+			status: 'active',
+		})
+		expect(result.totalActiveBacking.toFixed()).toBe('2.5')
+		expect(result.syncing).toBe(true)
+		expect(result.value).toBe('...')
+		expect(getActiveValidator).toHaveBeenCalledWith('validator')
+	},
+)


### PR DESCRIPTION
Detailed nomination lists on Polkadot waited for era exposures to finish syncing before mounting the staking API query, and their status labels still came from node data. Fetch nominee status and `activeBacking` as soon as the nominator, nomination targets, and active era are known. The pool canvas also builds its detailed rows from known targets without waiting for validator entries.

Pass each API nominee result once to `DetailedItem`, which uses its status and converts `activeBacking` from planck through the existing display helper. Simple views retain their previous node-backed behavior, including on non-Polkadot networks. This requires the staking API's `getNomineesStatus.statuses.activeBacking` field.

Validation:

- All 104 tests pass, including backing precision, API loading, zero backing, and node fallback coverage.
- Workspace lint and license checks pass.
- Staking app TypeScript check and Vite development build pass.
