### PR TITLE
feat(refactor): Speed up validator status and total stake syncing

### DIFF
--- a/packages/app-staking/src/contexts/EraStakers/index.tsx
+++ b/packages/app-staking/src/contexts/EraStakers/index.tsx
@@ -5,7 +5,7 @@ import { useActiveAccount } from '@polkadot-cloud/connect'
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
 import { planckToUnit, setStateWithRef } from '@w3ux/utils'
 import { getStakingChainData } from 'consts/util'
-import { removeSyncing, setSyncing } from 'global-bus'
+import { getActiveEra, getNetwork, removeSyncing, setSyncing } from 'global-bus'
 import { useApi } from 'hooks/useApi'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
@@ -42,6 +42,10 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 	// Store eras stakers in state
 	const [eraStakers, setEraStakers] = useState<EraStakers>(defaultEraStakers)
 	const eraStakersRef = useRef(eraStakers)
+
+	// Validator totals are available before paged nominator exposures.
+	const [validatorOverviews, setValidatorOverviews] =
+		useState<EraStakersContextInterface['validatorOverviews']>()
 
 	// Store the total active nominators
 	const [activeNominatorsCount, setActiveNominatorsCount] = useState<number>(0)
@@ -108,7 +112,12 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 			activeEra.index,
 		)
 		// Overview entries define the active validator set and are available before paged exposures.
-		setActiveValidators(overviews.length)
+		if (getNetwork() === network && getActiveEra().index === Number(era)) {
+			setActiveValidators(overviews.length)
+			setValidatorOverviews(
+				new Map(overviews.map(([[, address], entry]) => [address, entry])),
+			)
+		}
 
 		let exposures: Exposure[] = []
 		const localExposures = getLocalEraExposures(
@@ -301,11 +310,12 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 	}, [activeAddress])
 
 	useEffectIgnoreInitial(() => {
+		setValidatorOverviews(undefined)
 		if (getApiStatus(network) === 'connecting') {
 			setActiveValidators(0)
 			setStateWithRef(defaultEraStakers, setEraStakers, eraStakersRef)
 		}
-	}, [getApiStatus(network)])
+	}, [network, activeEra.index, getApiStatus(network)])
 
 	// Handle syncing with eraStakers
 	useEffectIgnoreInitial(() => {
@@ -324,6 +334,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 			}
 		}
 	}, [
+		network,
 		isReady,
 		activeEra.index,
 		pluginEnabled('staking_api'),
@@ -334,6 +345,7 @@ export const EraStakersProvider = ({ children }: { children: ReactNode }) => {
 		<EraStakersContext.Provider
 			value={{
 				eraStakers,
+				validatorOverviews,
 				activeValidators,
 				activeNominatorsCount,
 				getNominationsStatusFromEraStakers,

--- a/packages/app-staking/src/contexts/EraStakers/types.ts
+++ b/packages/app-staking/src/contexts/EraStakers/types.ts
@@ -3,6 +3,7 @@
 
 import type {
 	ActiveAccountOwnStake,
+	ErasStakersOverviewEntries,
 	MaybeAddress,
 	NominationStatus,
 	Staker,
@@ -10,6 +11,9 @@ import type {
 
 export interface EraStakersContextInterface {
 	eraStakers: EraStakers
+	validatorOverviews:
+		| ReadonlyMap<string, ErasStakersOverviewEntries[number][1]>
+		| undefined
 	activeValidators: number
 	activeNominatorsCount: number
 	getNominationsStatusFromEraStakers: (

--- a/packages/app-staking/src/library/ValidatorList/ValidatorSummary.tsx
+++ b/packages/app-staking/src/library/ValidatorList/ValidatorSummary.tsx
@@ -4,10 +4,9 @@
 import { capitalizeFirstLetter } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { getStakingChainData } from 'consts/util'
+import { useEraStakers } from 'contexts/EraStakers'
 import type { ValidatorActivityTier } from 'contexts/Validators/types'
-import { useValidators as useValidatorEntries } from 'contexts/Validators/ValidatorEntries'
 import { useNetwork } from 'hooks/useNetwork'
-import { useSyncing } from 'hooks/useSyncing'
 import { useTranslation } from 'react-i18next'
 import type { ValidatorStatus } from 'types'
 import { ListItem } from 'ui-app/ListItem'
@@ -36,16 +35,25 @@ export const useValidatorSummaryData = ({
 	selfStake,
 	selfStakeMax,
 	status,
+	statusActive,
 	statusLabel: statusLabelOverride,
 	statusValue,
 }: ValidatorSummaryProps) => {
 	const { t, i18n } = useTranslation('app')
-	const { syncing } = useSyncing()
 	const { network } = useNetwork()
-	const { getValidatorTotalStake } = useValidatorEntries()
+	const { validatorOverviews } = useEraStakers()
 	const { units } = getStakingChainData(network)
 
-	const validatorStatus = syncing ? 'waiting' : status
+	// Explicit API summaries have their own status and loading state. Node summaries need only the
+	// overview, not validator entries, paged nominators, or account sync.
+	const hasStatusOverride = statusActive !== undefined
+	const syncing = !hasStatusOverride && validatorOverviews === undefined
+	const overview = validatorOverviews?.get(address)
+	const validatorStatus = hasStatusOverride
+		? status
+		: overview
+			? 'active'
+			: 'waiting'
 	const statusLabel =
 		statusLabelOverride ??
 		(syncing
@@ -58,8 +66,8 @@ export const useValidatorSummaryData = ({
 			? statusValue.isGreaterThan(0)
 				? formatCompactNumber(statusValue.toNumber(), i18n.resolvedLanguage)
 				: undefined
-			: !syncing && validatorStatus !== 'waiting'
-				? planckToUnitBn(new BigNumber(getValidatorTotalStake(address)), units)
+			: !hasStatusOverride && overview
+				? planckToUnitBn(new BigNumber(overview.total), units)
 						.integerValue()
 						.toFormat()
 				: undefined

--- a/packages/app-staking/src/library/ValidatorList/useValidatorSelfStake.ts
+++ b/packages/app-staking/src/library/ValidatorList/useValidatorSelfStake.ts
@@ -8,8 +8,8 @@ import { isMaxSelfStake, planckToUnitBn } from 'utils'
 
 export const useValidatorSelfStake = (address: string, units: number) => {
 	const hardCapSelfStake = useHardCapSelfStake()
-	const { getActiveValidator } = useEraStakers()
-	const validatorOwnStake = getActiveValidator(address)?.own
+	const { validatorOverviews } = useEraStakers()
+	const validatorOwnStake = validatorOverviews?.get(address)?.own
 	const selfStakePlanck =
 		validatorOwnStake !== undefined
 			? new BigNumber(validatorOwnStake)

--- a/packages/tests/src/validatorSummary.test.ts
+++ b/packages/tests/src/validatorSummary.test.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { ErasStakersOverviewEntries } from 'types'
+import { stringToBn } from 'utils'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { useValidatorSelfStake } from '../../app-staking/src/library/ValidatorList/useValidatorSelfStake'
+import { useValidatorSummaryData } from '../../app-staking/src/library/ValidatorList/ValidatorSummary'
+
+const { node, getValidatorTotalStake, getActiveValidator } = vi.hoisted(() => ({
+	node: {
+		syncing: true,
+		overviews: undefined as
+			| Map<string, ErasStakersOverviewEntries[number][1]>
+			| undefined,
+	},
+	getValidatorTotalStake: vi.fn(),
+	getActiveValidator: vi.fn(),
+}))
+
+vi.mock('contexts/EraStakers', () => ({
+	useEraStakers: () => ({
+		validatorOverviews: node.overviews,
+		eraStakers: { stakers: [], activeAccountOwnStake: [] },
+		getActiveValidator,
+	}),
+}))
+vi.mock('contexts/Validators/ValidatorEntries', () => ({
+	useValidators: () => ({ getValidatorTotalStake }),
+}))
+vi.mock('../../hooks/src/useSyncing', () => ({
+	useSyncing: () => ({ syncing: node.syncing }),
+}))
+vi.mock('../../hooks/src/useNetwork', () => ({
+	useNetwork: () => ({ network: 'polkadot' }),
+}))
+vi.mock('../../hooks/src/useStakingMetrics', () => ({
+	useHardCapSelfStake: () => undefined,
+}))
+vi.mock('../../consts/src/util', () => ({
+	getStakingChainData: () => ({ unit: 'DOT', units: 10 }),
+}))
+vi.mock('../../app-staking/src/library/ListItem/Labels/ActivityTier', () => ({
+	ActivityTier: () => null,
+}))
+vi.mock(
+	'../../app-staking/node_modules/react-i18next/dist/es/index.js',
+	() => ({
+		useTranslation: () => ({
+			t: (key: string) => key,
+			i18n: { resolvedLanguage: 'en' },
+		}),
+	}),
+)
+
+const props = {
+	address: 'validator',
+	// The injected status still waits for paged exposures.
+	status: 'waiting' as const,
+	selfStakeMax: false,
+	unit: 'DOT',
+}
+
+beforeEach(() => {
+	vi.resetAllMocks()
+	node.syncing = true
+	node.overviews = new Map([
+		[
+			'validator',
+			{
+				own: 25000000000n,
+				total: 12345678901234567890n,
+				nominatorCount: 500,
+				pageCount: 2,
+			},
+		],
+	])
+})
+
+test('detailed summaries show overview status and total stake while paged exposures and account checks are pending', () => {
+	const result = useValidatorSummaryData(props)
+	expect(result.validatorStatus).toBe('active')
+	expect(result.statusLabel).toBe('listItemActive')
+	expect(result.totalStake).toBe('1,234,567,890')
+	expect(getValidatorTotalStake).not.toHaveBeenCalled()
+	expect(getActiveValidator).not.toHaveBeenCalled()
+})
+
+test('summaries keep loading until overviews arrive even if global sync has finished', () => {
+	node.syncing = false
+	node.overviews = undefined
+	const result = useValidatorSummaryData({ ...props, status: 'active' })
+	expect(result.statusLabel).toBe('syncing')
+	expect(result.validatorStatus).toBe('waiting')
+	expect(result.totalStake).toBeUndefined()
+})
+
+test('an address absent from a completed overview is waiting even with a stale active status', () => {
+	node.overviews = new Map()
+	const result = useValidatorSummaryData({ ...props, status: 'active' })
+	expect(result.statusLabel).toBe('Waiting')
+	expect(result.validatorStatus).toBe('waiting')
+	expect(result.totalStake).toBeUndefined()
+})
+
+test('active zero stake remains distinct from missing overview data', () => {
+	node.overviews!.get('validator')!.total = 0n
+	const result = useValidatorSummaryData(props)
+	expect(result.validatorStatus).toBe('active')
+	expect(result.totalStake).toBe('0')
+})
+
+test('API backing stake and status override node totals', () => {
+	const result = useValidatorSummaryData({
+		...props,
+		statusActive: true,
+		statusLabel: 'backing',
+		statusValue: stringToBn('12.5'),
+	})
+	expect(result.statusLabel).toBe('backing')
+	expect(result.totalStake).toBe('12.5')
+})
+
+test.each([undefined, stringToBn('0')])(
+	'empty API stake (%s) does not fall back to node totals',
+	(statusValue) => {
+		const result = useValidatorSummaryData({
+			...props,
+			statusActive: false,
+			statusLabel: 'waiting',
+			statusValue,
+		})
+		expect(result.statusLabel).toBe('waiting')
+		expect(result.totalStake).toBeUndefined()
+		expect(getValidatorTotalStake).not.toHaveBeenCalled()
+	},
+)
+
+test('self stake uses the overview before paged nominators load', () => {
+	const result = useValidatorSelfStake('validator', 10)
+	expect(result.selfStake?.toFixed()).toBe('2.5')
+	expect(result.selfStakeMax).toBe(false)
+	expect(getActiveValidator).not.toHaveBeenCalled()
+})
+
+test('missing overviews do not reuse self stake from older exposures', () => {
+	node.overviews = undefined
+	getActiveValidator.mockReturnValue({ own: 25000000000n })
+	expect(useValidatorSelfStake('validator', 10).selfStake).toBeUndefined()
+	expect(getActiveValidator).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
ManageNominations detailed items could keep showing `Syncing` and hide total stake while paged nominator exposures and unrelated account checks completed. Publish the existing active-era validator overview response immediately, and use it for detailed validator status, total stake, and self stake.

The overview map resets when the network, era, or connection status changes, and responses for a different network or era are ignored. Explicit staking API status and backing-stake overrides remain authoritative, including empty values. This reuses the existing node request and keeps full paged exposures available for nomination backing calculations.

Validation:

- All 113 tests pass, including 9 regression cases covering pending exposures, overview loading, waiting validators, zero stake, API overrides, and self stake.
- Biome checks pass for all changed files.
- Staking `build:verify` passes; nominate and validators TypeScript checks pass.

Production latency has not been benchmarked; the change removes the bulk-exposure and global-sync dependencies from these fields.
