### PR TITLE
feat: Add detailed validator list items on Kusama

### DIFF
--- a/packages/app-staking/src/hooks/useValidatorDetailsEnabled/index.ts
+++ b/packages/app-staking/src/hooks/useValidatorDetailsEnabled/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useNetwork } from 'hooks/useNetwork'
+import { usePlugins } from 'hooks/usePlugins'
+
+// Basic API metrics support enhanced layouts independently of retainment and warnings.
+export const useValidatorDetailsEnabled = () => {
+	const { network } = useNetwork()
+	const { pluginEnabled } = usePlugins()
+	return (
+		pluginEnabled('staking_api') &&
+		(network === 'polkadot' || network === 'kusama')
+	)
+}

--- a/packages/app-staking/src/library/GenerateNominations/NominationsView.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/NominationsView.tsx
@@ -9,6 +9,7 @@ import { useManageNominations } from 'contexts/ManageNominations'
 import { useApi } from 'hooks/useApi'
 import { useNetwork } from 'hooks/useNetwork'
 import { useNominationHealth } from 'hooks/useNominationHealth'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { useValidatorWarnings } from 'hooks/useValidatorWarnings'
 import { ValidatorListInner } from 'library/ValidatorList'
 import { useValidatorDetails } from 'library/ValidatorList/useValidatorDetails'
@@ -55,16 +56,16 @@ export const NominationsView = ({
 	} = useManageNominations()
 	const { isReady } = useApi()
 	const { network } = useNetwork()
-	const { active: healthCheckActive, retainmentStatsEnabled } =
-		useNominationHealth()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
+	const { active: healthCheckActive } = useNominationHealth()
 	const { activeAddress } = useActiveAccount()
 	const { accountsInitialised, isReadOnlyAccount } = useImportedAccounts()
 
 	// Derive layout and visibility once for use across both presentation modes.
 	const listReady = isReady && method !== null
 
-	// Use rows when retainment stats are enabled.
-	const listFormat = retainmentStatsEnabled ? 'row' : 'col'
+	// Use rows for enhanced validator details.
+	const listFormat = validatorDetailsEnabled ? 'row' : 'col'
 
 	// Show method selection until a method is chosen.
 	const showMethodSelection = !isReadOnlyAccount(activeAddress) && !method
@@ -82,7 +83,7 @@ export const NominationsView = ({
 	const validatorAddresses = nominations.map(({ address }) => address)
 	const validatorDetails = useValidatorDetails(
 		validatorAddresses,
-		retainmentStatsEnabled && listReady && !fetching,
+		validatorDetailsEnabled && listReady && !fetching,
 	)
 	const validatorWarnings = useValidatorWarnings(
 		network,

--- a/packages/app-staking/src/library/NominationList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/NominationList/DetailedItem.tsx
@@ -4,6 +4,7 @@
 import { getStakingChainData } from 'consts/util'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useNetwork } from 'hooks/useNetwork'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { getValidatorItemWarnings } from 'library/GenerateNominations/utils'
 import { getIdentityDisplay } from 'library/List/Utils'
 import { CopyAddress } from 'library/ListItem/Buttons/CopyAddress'
@@ -48,6 +49,7 @@ export const DetailedItem = ({
 }: ItemProps) => {
 	const { t } = useTranslation('app')
 	const { network } = useNetwork()
+	const retainmentEnabled = useRetainmentStatsEnabled()
 	const { validatorIdentities, validatorSupers } = useValidators()
 	const { address, prefs, validatorStatus } = validator
 	const { unit, units } = getStakingChainData(network)
@@ -74,7 +76,9 @@ export const DetailedItem = ({
 		window: retainmentWindow,
 		setWindow: setRetainmentWindow,
 	} = useRetainmentWindow(retainment?.retainment)
-	const itemWarnings = getValidatorItemWarnings(warnings, retainment)
+	const itemWarnings = retainmentEnabled
+		? getValidatorItemWarnings(warnings, retainment)
+		: []
 	const retainmentStats = useRetainmentStatsData({
 		period,
 		selfStakeMax,
@@ -96,7 +100,7 @@ export const DetailedItem = ({
 	const retainmentHistoryDisabled =
 		isPreloading || retainmentPeriods.length === 0
 	const showRetainmentHistory =
-		displayFor !== 'canvas' && displayFor !== 'modal'
+		retainmentEnabled && displayFor !== 'canvas' && displayFor !== 'modal'
 	const openRetainmentHistory = useOpenRetainmentHistory({
 		periods: retainmentPeriods,
 		selfStakeMax,
@@ -112,6 +116,7 @@ export const DetailedItem = ({
 	if (format === 'row') {
 		return (
 			<ValidatorBar
+				showRetainment={retainmentEnabled}
 				actions={
 					<RowActionsMenu
 						address={address}
@@ -176,6 +181,7 @@ export const DetailedItem = ({
 
 	return (
 		<ValidatorCard
+			showRetainment={retainmentEnabled}
 			actions={cardActions}
 			address={address}
 			blocked={prefs?.blocked === true}

--- a/packages/app-staking/src/library/NominationList/Item.tsx
+++ b/packages/app-staking/src/library/NominationList/Item.tsx
@@ -1,15 +1,15 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { BasicItem } from './BasicItem'
 import { DetailedItem } from './DetailedItem'
 import type { ItemProps } from './types'
 
 export const Item = (props: ItemProps) => {
-	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 
-	return retainmentStatsEnabled ? (
+	return validatorDetailsEnabled ? (
 		<DetailedItem {...props} />
 	) : (
 		<BasicItem {...props} />

--- a/packages/app-staking/src/library/NominationList/index.tsx
+++ b/packages/app-staking/src/library/NominationList/index.tsx
@@ -9,6 +9,7 @@ import { useApi } from 'hooks/useApi'
 import { useErasPerDay } from 'hooks/useErasPerDay'
 import { useNetwork } from 'hooks/useNetwork'
 import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { useValidatorWarnings } from 'hooks/useValidatorWarnings'
 import { FilterHeaderWrapper, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer, MotionItem } from 'library/List/MotionContainer'
@@ -41,6 +42,7 @@ export const NominationListInner = ({
 	const { network } = useNetwork()
 	const { erasPerDay } = useErasPerDay()
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 	const { listFormat, setListFormat } = useList()
 	const { activeEra } = useApi()
 	const { activeAddress } = useActiveAccount()
@@ -72,7 +74,7 @@ export const NominationListInner = ({
 
 	const forceCardLayout = useForceCardLayout()
 	const effectiveListFormat =
-		retainmentStatsEnabled && forceCardLayout ? 'col' : listFormat
+		validatorDetailsEnabled && forceCardLayout ? 'col' : listFormat
 
 	// Store all API-backed detailed card data by request key.
 	const [detailsByKey, setDetailsByKey] = useState<
@@ -98,13 +100,14 @@ export const NominationListInner = ({
 				network,
 				era: activeEra.index,
 				rewardRateDepth: erasPerDay,
+				includeRetainment: retainmentStatsEnabled,
 				validators: addresses,
 			}),
-		[network, activeEra.index, erasPerDay, addresses],
+		[network, activeEra.index, erasPerDay, addresses, retainmentStatsEnabled],
 	)
 	const details = detailsByKey[detailsKey]
 	const detailsPreloading =
-		retainmentStatsEnabled && validators.length > 0 && details === undefined
+		validatorDetailsEnabled && validators.length > 0 && details === undefined
 	const performanceByAddress = useMemo(
 		() =>
 			new Map(
@@ -144,13 +147,13 @@ export const NominationListInner = ({
 	const { data: rates } = useValidatorRewardRates(
 		addresses,
 		erasPerDay,
-		!retainmentStatsEnabled,
+		!validatorDetailsEnabled,
 	)
 
 	// Fetch all data needed by supported detailed nomination cards in one GraphQL operation.
 	const getDetailedData = async (key: string) => {
 		if (
-			!retainmentStatsEnabled ||
+			!validatorDetailsEnabled ||
 			activeEra.index === 0 ||
 			addresses.length === 0 ||
 			detailsByKey[key] !== undefined
@@ -163,6 +166,7 @@ export const NominationListInner = ({
 			Math.max(activeEra.index - 1, 0),
 			erasPerDay,
 			30,
+			{ includeRetainment: retainmentStatsEnabled },
 		)
 		setDetailsByKey((current) => ({ ...current, [key]: results }))
 	}
@@ -170,23 +174,23 @@ export const NominationListInner = ({
 	// Fetch detailed card data when the visible validator set changes.
 	useEffect(() => {
 		getDetailedData(detailsKey)
-	}, [detailsKey, retainmentStatsEnabled])
+	}, [detailsKey, validatorDetailsEnabled])
 
 	// Handle modal resize on list format or content change
 	useEffect(() => {
 		maybeHandleModalResize()
-	}, [effectiveListFormat, pageKey, retainmentStatsEnabled])
+	}, [effectiveListFormat, pageKey, validatorDetailsEnabled])
 
 	return (
 		<ListWrapper>
 			<List
-				$flexBasisLarge={retainmentStatsEnabled ? '50%' : '33.33%'}
-				$twoColumnMinWidth={retainmentStatsEnabled ? 1350 : undefined}
+				$flexBasisLarge={validatorDetailsEnabled ? '50%' : '33.33%'}
+				$twoColumnMinWidth={validatorDetailsEnabled ? 1350 : undefined}
 			>
 				<ListFormatHeader>
 					<div />
 					<div>
-						{!(retainmentStatsEnabled && forceCardLayout) && (
+						{!(validatorDetailsEnabled && forceCardLayout) && (
 							<ListItem.FormatToggle
 								onChange={setListFormat}
 								value={listFormat}
@@ -214,7 +218,7 @@ export const NominationListInner = ({
 									}
 									isPreloading={detailsPreloading}
 									rate={
-										retainmentStatsEnabled
+										validatorDetailsEnabled
 											? rateByAddress.get(validator.address)
 											: rates?.[validator.address]
 									}

--- a/packages/app-staking/src/library/ValidatorList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/ValidatorList/DetailedItem.tsx
@@ -5,6 +5,7 @@ import { getStakingChainData } from 'consts/util'
 import { useList } from 'contexts/List'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useNetwork } from 'hooks/useNetwork'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { getValidatorItemWarnings } from 'library/GenerateNominations/utils'
 import { getIdentityDisplay } from 'library/List/Utils'
 import { CopyAddress } from 'library/ListItem/Buttons/CopyAddress'
@@ -49,6 +50,7 @@ export const DetailedItem = ({
 	isPreloading,
 }: ItemProps) => {
 	const { network } = useNetwork()
+	const retainmentEnabled = useRetainmentStatsEnabled()
 	const { selectable, selected } = useList()
 	const { validatorIdentities, validatorSupers } = useValidators()
 	const { address, prefs, validatorStatus } = validator
@@ -59,9 +61,10 @@ export const DetailedItem = ({
 		window: retainmentWindow,
 		setWindow: setRetainmentWindow,
 	} = useRetainmentWindow(retainment?.retainment)
-	const itemWarnings = highlightRetainmentWarnings
-		? getValidatorItemWarnings(warnings, retainment)
-		: []
+	const itemWarnings =
+		retainmentEnabled && highlightRetainmentWarnings
+			? getValidatorItemWarnings(warnings, retainment)
+			: []
 	const retainmentStats = useRetainmentStatsData({
 		period,
 		selfStakeMax,
@@ -79,7 +82,7 @@ export const DetailedItem = ({
 	const validatorDisplay = validatorIdentity.node
 	const retainmentPeriods = retainment?.months.slice(0, 6) ?? []
 	const showRetainmentHistory =
-		displayFor !== 'canvas' && displayFor !== 'modal'
+		retainmentEnabled && displayFor !== 'canvas' && displayFor !== 'modal'
 	const openRetainmentHistory = useOpenRetainmentHistory({
 		periods: retainmentPeriods,
 		selfStakeMax,
@@ -92,7 +95,8 @@ export const DetailedItem = ({
 		? openRetainmentHistory
 		: undefined
 
-	if (isPreloading) {
+	// Without retainment, keep the shorter layout and preload only the pending metrics.
+	if (isPreloading && retainmentEnabled) {
 		return <DetailedItemPreloader format={format} />
 	}
 
@@ -145,6 +149,7 @@ export const DetailedItem = ({
 	if (format === 'row') {
 		return (
 			<ValidatorBar
+				showRetainment={retainmentEnabled}
 				actions={
 					<RowActionsMenu
 						address={address}
@@ -163,6 +168,7 @@ export const DetailedItem = ({
 				}
 				displayFor={displayFor}
 				eraPoints={eraPoints}
+				isPreloading={isPreloading}
 				onRetainmentHistory={onRetainmentHistory}
 				rate={rateAfterCommission}
 				retainmentHistoryDisabled={retainmentPeriods.length === 0}
@@ -181,11 +187,13 @@ export const DetailedItem = ({
 
 	return (
 		<ValidatorCard
+			showRetainment={retainmentEnabled}
 			actions={cardActions}
 			address={address}
 			blocked={prefs?.blocked === true}
 			displayFor={displayFor}
 			eraPoints={eraPoints}
+			isActivityPreloading={isPreloading}
 			headerStart={selectable ? <Select item={validator} /> : undefined}
 			identity={<Identity address={address} />}
 			retainmentStats={retainmentStats}
@@ -195,6 +203,7 @@ export const DetailedItem = ({
 			summary={
 				<ValidatorSummary
 					address={address}
+					isRatePreloading={isPreloading}
 					rate={rateAfterCommission}
 					selfStake={selfStake}
 					selfStakeMax={selfStakeMax}

--- a/packages/app-staking/src/library/ValidatorList/Item.tsx
+++ b/packages/app-staking/src/library/ValidatorList/Item.tsx
@@ -1,15 +1,15 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { BasicItem } from './BasicItem'
 import { DetailedItem } from './DetailedItem'
 import type { ItemProps } from './types'
 
 export const Item = (props: ItemProps) => {
-	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 
-	return retainmentStatsEnabled ? (
+	return validatorDetailsEnabled ? (
 		<DetailedItem {...props} />
 	) : (
 		<BasicItem {...props} />

--- a/packages/app-staking/src/library/ValidatorList/ValidatorBar.tsx
+++ b/packages/app-staking/src/library/ValidatorList/ValidatorBar.tsx
@@ -25,6 +25,7 @@ import { Identity } from '../ListItem/Labels/Identity'
 import { ValidatorSummaryMetrics } from './ValidatorSummary'
 
 interface ValidatorBarProps {
+	showRetainment?: boolean
 	actions: ReactNode
 	activityTier?: ValidatorActivityTier | null
 	displayFor: DisplayFor
@@ -54,6 +55,7 @@ interface ValidatorBarProps {
 }
 
 export const ValidatorBar = ({
+	showRetainment = true,
 	actions,
 	activityTier,
 	displayFor,
@@ -100,8 +102,9 @@ export const ValidatorBar = ({
 		<ListItem.Row
 			displayFor={displayFor}
 			rowVariant="validator"
+			showRetainment={showRetainment}
 			selected={selected}
-			statusAccent={retainmentStats.statusAccent}
+			statusAccent={showRetainment ? retainmentStats.statusAccent : undefined}
 		>
 			<ListItem.RowHeader data-section="identity">
 				{t('identity')}
@@ -109,22 +112,24 @@ export const ValidatorBar = ({
 			<ListItem.RowHeader data-section="performance">
 				{t('performance')}
 			</ListItem.RowHeader>
-			<ListItem.RowHeader data-section="retainment">
-				<span>{retainmentLabel}</span>
-				{onRetainmentHistory && (
-					<RetainmentHistory
-						disabled={retainmentHistoryDisabled}
-						iconOnly
-						onClick={onRetainmentHistory}
+			{showRetainment && (
+				<ListItem.RowHeader data-section="retainment">
+					<span>{retainmentLabel}</span>
+					{onRetainmentHistory && (
+						<RetainmentHistory
+							disabled={retainmentHistoryDisabled}
+							iconOnly
+							onClick={onRetainmentHistory}
+						/>
+					)}
+					<RetainmentWindowToggle
+						alignEnd
+						disabled={retainmentPreloading}
+						onChange={onRetainmentWindowChange}
+						value={retainmentWindow}
 					/>
-				)}
-				<RetainmentWindowToggle
-					alignEnd
-					disabled={retainmentPreloading}
-					onChange={onRetainmentWindowChange}
-					value={retainmentWindow}
-				/>
-			</ListItem.RowHeader>
+				</ListItem.RowHeader>
+			)}
 			<ListItem.RowIdentity>
 				{selectable && <Select item={validator} />}
 				<ListItem.Identity>
@@ -172,29 +177,31 @@ export const ValidatorBar = ({
 				</ListItem.RowMetricGroup>
 			</ListItem.RowPerformance>
 
-			<ListItem.RowMetricGroup
-				aria-label={retainmentLabel}
-				data-section="retainment"
-				role="group"
-			>
-				{[retainmentRate, compoundRate].map((stat) => (
-					<RetainmentMetric
-						compact
-						key={stat.label}
-						isPreloading={retainmentPreloading}
-						stat={stat}
-					/>
-				))}
-				{[selfStakeChange, netOutflow].map((stat) => (
-					<RetainmentMetric
-						compact
-						key={stat.label}
-						isPreloading={retainmentPreloading}
-						stat={stat}
-						unit={unit}
-					/>
-				))}
-			</ListItem.RowMetricGroup>
+			{showRetainment && (
+				<ListItem.RowMetricGroup
+					aria-label={retainmentLabel}
+					data-section="retainment"
+					role="group"
+				>
+					{[retainmentRate, compoundRate].map((stat) => (
+						<RetainmentMetric
+							compact
+							key={stat.label}
+							isPreloading={retainmentPreloading}
+							stat={stat}
+						/>
+					))}
+					{[selfStakeChange, netOutflow].map((stat) => (
+						<RetainmentMetric
+							compact
+							key={stat.label}
+							isPreloading={retainmentPreloading}
+							stat={stat}
+							unit={unit}
+						/>
+					))}
+				</ListItem.RowMetricGroup>
+			)}
 
 			{actions}
 			{warnings}

--- a/packages/app-staking/src/library/ValidatorList/ValidatorCard.tsx
+++ b/packages/app-staking/src/library/ValidatorList/ValidatorCard.tsx
@@ -15,6 +15,7 @@ import {
 } from 'ui-app/RetainmentStats'
 
 interface ValidatorCardProps {
+	showRetainment?: boolean
 	actions: ReactNode
 	address: string
 	activitySyncing?: boolean
@@ -35,6 +36,7 @@ interface ValidatorCardProps {
 }
 
 export const ValidatorCard = ({
+	showRetainment = true,
 	actions,
 	address,
 	activitySyncing,
@@ -59,7 +61,7 @@ export const ValidatorCard = ({
 		<DetailedCard.Root
 			displayFor={displayFor}
 			selected={selected}
-			statusAccent={retainmentStats.statusAccent}
+			statusAccent={showRetainment ? retainmentStats.statusAccent : undefined}
 		>
 			<DetailedCard.Top>
 				<DetailedCard.Header>
@@ -96,19 +98,21 @@ export const ValidatorCard = ({
 					</ListItem.Graph>
 				</ListItem.Activity>
 			</DetailedCard.Top>
-			<RetainmentStats
-				data={retainmentStats}
-				isPreloading={isRetainmentPreloading}
-				unit={unit}
-				windowToggle={
-					<RetainmentWindowToggle
-						alignEnd
-						disabled={isRetainmentPreloading}
-						onChange={onRetainmentWindowChange}
-						value={retainmentWindow}
-					/>
-				}
-			/>
+			{showRetainment && (
+				<RetainmentStats
+					data={retainmentStats}
+					isPreloading={isRetainmentPreloading}
+					unit={unit}
+					windowToggle={
+						<RetainmentWindowToggle
+							alignEnd
+							disabled={isRetainmentPreloading}
+							onChange={onRetainmentWindowChange}
+							value={retainmentWindow}
+						/>
+					}
+				/>
+			)}
 			{warnings}
 		</DetailedCard.Root>
 	)

--- a/packages/app-staking/src/library/ValidatorList/index.tsx
+++ b/packages/app-staking/src/library/ValidatorList/index.tsx
@@ -7,8 +7,8 @@ import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useValidatorRewardRates } from 'data-gate'
 import { useApi } from 'hooks/useApi'
 import { useErasPerDay } from 'hooks/useErasPerDay'
-import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { useSyncing } from 'hooks/useSyncing'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { FilterHeaderWrapper, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer, MotionItem } from 'library/List/MotionContainer'
 import { Pagination } from 'library/List/Pagination'
@@ -57,7 +57,7 @@ export const ValidatorListInner = ({
 }: ValidatorListProps) => {
 	const { t } = useTranslation()
 	const { syncing } = useSyncing()
-	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 	const { erasPerDay } = useErasPerDay()
 	const { setModalResize } = useOverlay().modal
 	const { injectValidatorListData } = useValidators()
@@ -91,7 +91,7 @@ export const ValidatorListInner = ({
 	const forceCardLayout = useForceCardLayout()
 	const effectiveListFormat =
 		forceListFormat ??
-		(retainmentStatsEnabled && forceCardLayout ? 'col' : listFormat)
+		(validatorDetailsEnabled && forceCardLayout ? 'col' : listFormat)
 
 	// Pagination
 	const pageLength: number = itemsPerPage || validators.length
@@ -109,7 +109,7 @@ export const ValidatorListInner = ({
 
 	const internalValidatorDetails = useValidatorDetails(
 		listItems.map(({ address }) => address),
-		retainmentStatsEnabled && suppliedValidatorDetails === undefined,
+		validatorDetailsEnabled && suppliedValidatorDetails === undefined,
 	)
 	const {
 		detailedAddresses,
@@ -128,7 +128,7 @@ export const ValidatorListInner = ({
 	const { data: rates } = useValidatorRewardRates(
 		listItems.map(({ address }) => address),
 		erasPerDay,
-		!retainmentStatsEnabled,
+		!validatorDetailsEnabled,
 	)
 
 	const setControls = (nextConfig: ValidatorListConfig) => {
@@ -139,13 +139,13 @@ export const ValidatorListInner = ({
 	// Handle modal resize on list format change
 	useEffect(() => {
 		maybeHandleModalResize()
-	}, [effectiveListFormat, validators, page, retainmentStatsEnabled])
+	}, [effectiveListFormat, validators, page, validatorDetailsEnabled])
 
 	return (
 		<ListWrapper>
 			<List
-				$flexBasisLarge={retainmentStatsEnabled ? '50%' : '33.33%'}
-				$twoColumnMinWidth={retainmentStatsEnabled ? 1350 : undefined}
+				$flexBasisLarge={validatorDetailsEnabled ? '50%' : '33.33%'}
+				$twoColumnMinWidth={validatorDetailsEnabled ? 1350 : undefined}
 			>
 				{showControls && (
 					<Controls
@@ -171,7 +171,7 @@ export const ValidatorListInner = ({
 						</div>
 						<div>
 							{allowListFormat &&
-								!(retainmentStatsEnabled && forceCardLayout) && (
+								!(validatorDetailsEnabled && forceCardLayout) && (
 									<ListItem.FormatToggle
 										onChange={setListFormat}
 										value={listFormat}
@@ -204,13 +204,13 @@ export const ValidatorListInner = ({
 										EMPTY_ERA_POINTS
 									}
 									rate={
-										retainmentStatsEnabled
+										validatorDetailsEnabled
 											? rateByAddress.get(validator.address)
 											: rates?.[validator.address]
 									}
 									retainment={retainmentByAddress.get(validator.address)}
 									isPreloading={
-										retainmentStatsEnabled &&
+										validatorDetailsEnabled &&
 										activeEra.index > 0 &&
 										!detailedAddresses.has(validator.address)
 									}

--- a/packages/app-staking/src/library/ValidatorList/useValidatorDetails.ts
+++ b/packages/app-staking/src/library/ValidatorList/useValidatorDetails.ts
@@ -4,6 +4,7 @@
 import { useApi } from 'hooks/useApi'
 import { useErasPerDay } from 'hooks/useErasPerDay'
 import { useNetwork } from 'hooks/useNetwork'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { fetchValidatorDetailsBatch } from 'plugin-staking-api'
 import type { ValidatorDetailsBatchData } from 'plugin-staking-api/types'
 import { useEffect, useMemo, useState } from 'react'
@@ -41,6 +42,7 @@ export const useValidatorDetails = (
 	enabled: boolean,
 ): ValidatorDetailsData => {
 	const { network } = useNetwork()
+	const includeRetainment = useRetainmentStatsEnabled()
 	const { erasPerDay } = useErasPerDay()
 	const { activeEra } = useApi()
 
@@ -59,7 +61,7 @@ export const useValidatorDetails = (
 	const stableAddresses = useMemo(() => [...addresses], [addressesKey])
 
 	// Cache key for the current network, era, and reward-rate depth.
-	const scopeKey = `${network}:${era}:${erasPerDay}`
+	const scopeKey = `${network}:${era}:${erasPerDay}:${includeRetainment}`
 
 	// Cached details for the current scope.
 	const scopedDetails = detailsByScope[scopeKey]
@@ -90,6 +92,7 @@ export const useValidatorDetails = (
 			era - 1,
 			erasPerDay,
 			ERA_POINTS_DEPTH,
+			{ includeRetainment },
 		).then((data) => {
 			if (!active) {
 				return
@@ -112,7 +115,15 @@ export const useValidatorDetails = (
 		return () => {
 			active = false
 		}
-	}, [enabled, era, erasPerDay, network, pendingAddresses, scopeKey])
+	}, [
+		enabled,
+		era,
+		erasPerDay,
+		network,
+		pendingAddresses,
+		scopeKey,
+		includeRetainment,
+	])
 
 	// Validator details indexed by address for list consumption.
 	const detailsByAddress = useMemo(

--- a/packages/app-staking/src/pages/Validators/ValidatorsNode.tsx
+++ b/packages/app-staking/src/pages/Validators/ValidatorsNode.tsx
@@ -4,6 +4,7 @@
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useApi } from 'hooks/useApi'
 import { useValidatorStats } from 'hooks/useStats'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { Stats } from 'library/Stats'
 import { ValidatorList } from 'library/ValidatorList'
 import { useTranslation } from 'react-i18next'
@@ -20,6 +21,7 @@ export const ValidatorsNode = ({
 }) => {
 	const { t } = useTranslation('pages')
 	const { isReady } = useApi()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 	const { getValidators } = useValidators()
 	const validators = getValidators()
 	const { activeValidators, totalValidators, minValidatorBond } =
@@ -55,8 +57,8 @@ export const ValidatorsNode = ({
 										order: 'ACTIVITY',
 										search: '',
 									}}
-									allowListFormat={false}
-									forceListFormat="col"
+									allowListFormat={validatorDetailsEnabled}
+									forceListFormat={validatorDetailsEnabled ? undefined : 'col'}
 									itemsPerPage={50}
 									showShareLink={showShareLink}
 									toggleFavorites={toggleFavorites}

--- a/packages/plugin-staking-api/src/queries/validatorDetailsBatch.ts
+++ b/packages/plugin-staking-api/src/queries/validatorDetailsBatch.ts
@@ -14,8 +14,9 @@ const QUERY = gql`
     $fromEra: Int!
     $rewardRateDepth: Int
     $eraPointsDepth: Int
+    $includeRetainment: Boolean!
   ) {
-    validatorRetainmentBatch(network: $network, validators: $validators) {
+    validatorRetainmentBatch(network: $network, validators: $validators) @include(if: $includeRetainment) {
       validator
       result {
         months { ...ValidatorRetainmentWindowFields }
@@ -53,15 +54,15 @@ const DEFAULT: ValidatorDetailsBatchData = {
 	validatorEraPointsBatch: [],
 }
 
-export const fetchValidatorDetailsBatch = (
+export const fetchValidatorDetailsBatch = async (
 	network: string,
 	validators: string[],
 	fromEra: number,
 	rewardRateDepth?: number,
 	eraPointsDepth?: number,
-	options?: { throwOnError?: boolean },
-) =>
-	fetchQuery<ValidatorDetailsBatchData>(
+	options?: { throwOnError?: boolean; includeRetainment?: boolean },
+) => {
+	const data = await fetchQuery<ValidatorDetailsBatchData>(
 		QUERY,
 		{
 			network,
@@ -69,7 +70,14 @@ export const fetchValidatorDetailsBatch = (
 			fromEra,
 			rewardRateDepth,
 			eraPointsDepth,
+			includeRetainment: options?.includeRetainment ?? true,
 		},
 		DEFAULT,
 		options,
 	)
+
+	return {
+		...data,
+		validatorRetainmentBatch: data.validatorRetainmentBatch ?? [],
+	}
+}

--- a/packages/tests/src/validatorDetailsLayout.test.ts
+++ b/packages/tests/src/validatorDetailsLayout.test.ts
@@ -1,0 +1,137 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { expect, test, vi } from 'vitest'
+import { Tooltip } from '../../app-staking/node_modules/radix-ui/dist/index.mjs'
+import { createElement } from '../../app-staking/node_modules/react/index.js'
+import { renderToStaticMarkup } from '../../app-staking/node_modules/react-dom/server.node.js'
+import { useRetainmentStatsEnabled } from '../../app-staking/src/hooks/useRetainmentStatsEnabled'
+import { useValidatorDetailsEnabled } from '../../app-staking/src/hooks/useValidatorDetailsEnabled'
+import { ValidatorBar } from '../../app-staking/src/library/ValidatorList/ValidatorBar'
+import { ValidatorCard } from '../../app-staking/src/library/ValidatorList/ValidatorCard'
+import { useRetainmentStatsData } from '../../ui-app/src/RetainmentStats/useRetainmentStatsData'
+
+const { state } = vi.hoisted(() => ({
+	state: { network: 'kusama', api: true },
+}))
+vi.mock('../../hooks/src/useNetwork', () => ({
+	useNetwork: () => ({ network: state.network }),
+}))
+vi.mock('../../hooks/src/usePlugins', () => ({
+	usePlugins: () => ({ pluginEnabled: () => state.api }),
+}))
+vi.mock('contexts/List', () => ({ useList: () => ({ selectable: false }) }))
+vi.mock('library/List/EraPointsGraph/HistoricalEraPoints', () => ({
+	HistoricalEraPoints: () => 'activity-graph',
+}))
+vi.mock('../../app-staking/src/library/ValidatorList/ValidatorSummary', () => ({
+	ValidatorSummaryMetrics: () => 'APY stake status',
+}))
+vi.mock('../../app-staking/src/library/ListItem/Labels/Identity', () => ({
+	Identity: () => 'validator-identity',
+}))
+vi.mock(
+	'../../app-staking/src/library/ListItem/Buttons/RetainmentHistory',
+	() => ({ RetainmentHistory: () => 'retainment-history' }),
+)
+vi.mock(
+	'../../app-staking/node_modules/react-i18next/dist/es/index.js',
+	() => ({
+		useTranslation: () => ({
+			t: (key: string) => key,
+			i18n: { resolvedLanguage: 'en' },
+		}),
+	}),
+)
+
+test.each([
+	['polkadot', true, true, true],
+	['kusama', true, true, false],
+	['polkadot', false, false, false],
+	['kusama', false, false, false],
+	['paseo', false, false, false],
+] as const)(
+	'%s API=%s selects enhanced=%s, retainment=%s',
+	(network, api, enhanced, retainment) => {
+		state.network = network
+		state.api = api
+		expect(useValidatorDetailsEnabled()).toBe(enhanced)
+		expect(useRetainmentStatsEnabled()).toBe(retainment)
+	},
+)
+
+const Fixture = ({
+	format,
+	showRetainment,
+}: {
+	format: 'row' | 'col'
+	showRetainment: boolean
+}) => {
+	const retainmentStats = useRetainmentStatsData({
+		selfStakeMax: false,
+		unit: 'KSM',
+		units: 12,
+		statusAccent: 'danger',
+	})
+	const common = {
+		showRetainment,
+		actions: 'copy share favorite',
+		displayFor: 'default' as const,
+		eraPoints: [],
+		retainmentStats,
+		retainmentWindow: 'THREE_MONTHS' as const,
+		onRetainmentWindowChange: () => {},
+		unit: 'KSM',
+	}
+	return format === 'row'
+		? createElement(ValidatorBar, {
+				...common,
+				selfStakeMax: false,
+				validator: {
+					address: 'alice',
+					prefs: { commission: 5, blocked: true },
+					validatorStatus: 'active',
+				},
+			})
+		: createElement(ValidatorCard, {
+				...common,
+				address: 'alice',
+				blocked: true,
+				identity: 'validator-identity',
+				summary: 'APY stake status',
+			})
+}
+
+test.each(['row', 'col'] as const)(
+	'%s omits unsupported retainment while keeping supported content',
+	(format) => {
+		const markup = renderToStaticMarkup(
+			createElement(Fixture, { format, showRetainment: false }),
+		)
+		expect(markup).toContain('validator-identity')
+		expect(markup).toContain('APY stake status')
+		expect(markup).toContain('activity-graph')
+		expect(markup).toContain('blocked')
+		expect(markup).toContain('copy share favorite')
+		expect(markup).not.toContain('data-section="retainment"')
+		expect(markup).not.toContain('retainment-history')
+		expect(markup).not.toContain('data-status-accent="danger"')
+		expect(markup).not.toContain('compoundRate')
+		if (format === 'row') expect(markup).toContain('data-retainment="false"')
+	},
+)
+
+test.each(['row', 'col'] as const)(
+	'%s retains supported retainment content',
+	(format) => {
+		const markup = renderToStaticMarkup(
+			createElement(
+				Tooltip.Provider,
+				null,
+				createElement(Fixture, { format, showRetainment: true }),
+			),
+		)
+		expect(markup).toContain('data-status-accent="danger"')
+		expect(markup).toContain('compound')
+	},
+)

--- a/packages/tests/src/validatorDetailsTransport.test.ts
+++ b/packages/tests/src/validatorDetailsTransport.test.ts
@@ -1,0 +1,88 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { afterAll, afterEach, expect, test, vi } from 'vitest'
+import {
+	GraphQLIncludeDirective,
+	getDirectiveValues,
+	parse,
+} from '../../plugin-staking-api/node_modules/graphql/index.js'
+import { client } from '../../plugin-staking-api/src/Client'
+import { fetchValidatorDetailsBatch } from '../../plugin-staking-api/src/queries/validatorDetailsBatch'
+
+const { httpFetch } = vi.hoisted(() => {
+	const httpFetch = vi.fn<typeof fetch>()
+	vi.stubGlobal('fetch', httpFetch)
+	return { httpFetch }
+})
+
+afterEach(async () => {
+	await client.clearStore()
+	httpFetch.mockReset()
+})
+
+afterAll(() => {
+	client.stop()
+	vi.unstubAllGlobals()
+})
+
+test.each([
+	['kusama', false],
+	['polkadot', true],
+] as const)(
+	'detail requests for %s execute only supported fields',
+	async (network, includeRetainment) => {
+		httpFetch.mockImplementation(async (_, options) => {
+			const { query, variables } = JSON.parse(String(options?.body))
+			const document = parse(query)
+			const operation = document.definitions.find(
+				(node) => node.kind === 'OperationDefinition',
+			)
+			if (operation?.kind !== 'OperationDefinition')
+				throw new Error('Missing query')
+			const fields = operation.selectionSet.selections
+				.filter(
+					(node) =>
+						node.kind === 'Field' &&
+						node.name.value !== '__typename' &&
+						getDirectiveValues(GraphQLIncludeDirective, node, {
+							sources: {},
+							coerced: variables,
+						})?.if !== false,
+				)
+				.map((node) => (node.kind === 'Field' ? node.name.value : ''))
+			expect(fields).toEqual(
+				includeRetainment
+					? [
+							'validatorRetainmentBatch',
+							'validatorAvgRewardRateBatch',
+							'validatorEraPointsBatch',
+						]
+					: ['validatorAvgRewardRateBatch', 'validatorEraPointsBatch'],
+			)
+			expect(variables.network).toBe(network)
+			return Response.json({
+				data: {
+					validatorAvgRewardRateBatch: [{ validator: 'alice', rate: 12 }],
+					validatorEraPointsBatch: [{ validator: 'alice', points: [] }],
+					...(includeRetainment ? { validatorRetainmentBatch: [] } : {}),
+				},
+			})
+		})
+		const result = await fetchValidatorDetailsBatch(
+			network,
+			['alice'],
+			100,
+			4,
+			30,
+			includeRetainment
+				? { throwOnError: true }
+				: { includeRetainment: false, throwOnError: true },
+		)
+		expect(result.validatorAvgRewardRateBatch).toEqual([
+			{ validator: 'alice', rate: 12 },
+		])
+		expect(result.validatorRetainmentBatch).toEqual([])
+		expect(httpFetch).toHaveBeenCalledTimes(1)
+	},
+)

--- a/packages/ui-app/src/ListItem/DetailedList/index.tsx
+++ b/packages/ui-app/src/ListItem/DetailedList/index.tsx
@@ -19,6 +19,7 @@ interface ItemShellProps extends ComponentPropsWithoutRef<'div'> {
 	displayFor?: DisplayFor
 	layout: 'card' | 'row'
 	rowVariant?: 'validator' | 'operator'
+	showRetainment?: boolean
 	selected?: boolean
 	statusAccent?: 'success' | 'warning' | 'danger'
 }
@@ -29,6 +30,7 @@ const ItemShell = ({
 	displayFor,
 	layout,
 	rowVariant,
+	showRetainment,
 	selected,
 	statusAccent,
 	...props
@@ -49,7 +51,11 @@ const ItemShell = ({
 			data-status-accent={statusAccent}
 		>
 			{layout === 'row' ? (
-				<div className={classes.barLayout} data-row-variant={rowVariant}>
+				<div
+					className={classes.barLayout}
+					data-row-variant={rowVariant}
+					data-retainment={showRetainment}
+				>
 					{children}
 				</div>
 			) : (

--- a/packages/ui-app/src/ListItem/DetailedList/styles/_row-layout.scss
+++ b/packages/ui-app/src/ListItem/DetailedList/styles/_row-layout.scss
@@ -138,3 +138,32 @@
 		}
 	}
 }
+
+// Enhanced validator bars without retainment use only identity, performance and actions.
+.barLayout[data-row-variant='validator'][data-retainment='false'] {
+	grid-template:
+		'identity-title performance-title actions' auto
+		'identity performance actions' minmax(3.8rem, auto) / minmax(10.5rem, 0.9fr)
+		minmax(26.75rem, 3.1fr) auto;
+}
+
+@container list-item-bar (max-width: 46rem) {
+	.barLayout[data-row-variant='validator'][data-retainment='false'] {
+		grid-template:
+			'identity-title actions' auto
+			'identity actions' minmax(3.8rem, auto)
+			'performance-title performance-title' auto
+			'performance performance' minmax(3.8rem, auto) / minmax(0, 1fr) auto;
+	}
+}
+
+@container list-item-bar (max-width: 29rem) {
+	.barLayout[data-row-variant='validator'][data-retainment='false'] {
+		grid-template:
+			'identity-title' auto
+			'identity' minmax(3.8rem, auto)
+			'performance-title' auto
+			'performance' auto
+			'actions' auto / minmax(0, 1fr);
+	}
+}


### PR DESCRIPTION
Enables detailed validator cards and bars on Kusama when the staking API is enabled. Validator lists, nomination lists and nomination generation now show activity graphs, APY, stake and status independently of retainment support.

- Omits unsupported retainment statistics, history controls and validator warnings on Kusama.
- Fetches reward rates and era points while skipping the retainment GraphQL field.
- Enables card/bar switching and adjusts responsive layouts to reclaim the retainment space.
- Keeps Kusama loading cards compact, with placeholders only for pending metrics.

Polkadot retains its existing retainment features. API-disabled layouts and validator-entry fetching remain unchanged.

Validated with 45 focused tests, lint/style checks, type checks for all three staking apps, the staking app build, and visual checks of both Kusama layouts.
