### PR TITLE
feat(refactor): Move `ValidatorEntries` to `data-gate`

### DIFF
--- a/packages/app-staking/src/canvas/OperatorValidators/index.tsx
+++ b/packages/app-staking/src/canvas/OperatorValidators/index.tsx
@@ -9,7 +9,6 @@ import { CloseCanvas, useOverlay } from 'ui-overlay'
 
 export const OperatorValidators = () => {
 	const { t } = useTranslation('app')
-	const { formatWithPrefs } = useValidators()
 	const {
 		config: { options },
 	} = useOverlay().canvas
@@ -20,6 +19,7 @@ export const OperatorValidators = () => {
 				(validator): validator is string => typeof validator === 'string',
 			)
 		: []
+	const { formatWithPrefs } = useValidators(validatorAddresses)
 	const validators = formatWithPrefs(validatorAddresses)
 	const operatorLabel = display || address
 

--- a/packages/app-staking/src/canvas/Pool/Nominations/index.tsx
+++ b/packages/app-staking/src/canvas/Pool/Nominations/index.tsx
@@ -3,7 +3,6 @@
 
 import { useBondedPools } from 'contexts/Pools/BondedPools'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
-import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { NominationList } from 'library/NominationList'
 import { useTranslation } from 'react-i18next'
 import { Subheading } from 'ui-core/canvas'
@@ -12,15 +11,12 @@ import { NominationsWrapper } from '../Wrappers'
 
 export const Nominations = ({ stash, poolId }: NominationsProps) => {
 	const { t } = useTranslation()
-	const { getValidators, formatWithPrefs } = useValidators()
-	const retainmentStatsEnabled = useRetainmentStatsEnabled()
 	const { poolsNominations } = useBondedPools()
 
 	// Extract validator entries from pool targets.
 	const targets = poolsNominations[poolId]?.targets || []
-	const filteredTargets = retainmentStatsEnabled
-		? formatWithPrefs(targets)
-		: getValidators().filter(({ address }) => targets.includes(address))
+	const { formatWithPrefs } = useValidators(targets)
+	const filteredTargets = formatWithPrefs(targets)
 
 	return (
 		<NominationsWrapper>

--- a/packages/app-staking/src/contexts/Validators/Utils.ts
+++ b/packages/app-staking/src/contexts/Validators/Utils.ts
@@ -1,11 +1,8 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-	LocalValidatorEntriesData,
-	ValidatorActivityTier,
-} from 'contexts/Validators/types'
-import type { NetworkId, Validator } from 'types'
+import type { ValidatorActivityTier } from 'contexts/Validators/types'
+import type { NetworkId } from 'types'
 
 const BELOW_BASELINE_ACTIVITY_CUTOFF = 0.9
 
@@ -34,32 +31,4 @@ export const getActivityTier = (
 export const getLocalFavorites = (network: NetworkId) => {
 	const localFavorites = localStorage.getItem(`${network}_favorites`)
 	return localFavorites !== null ? (JSON.parse(localFavorites) as string[]) : []
-}
-
-// Get local validator entries data for an era
-export const getLocalEraValidators = (network: NetworkId, era: string) => {
-	const data = localStorage.getItem(`${network}_validators`)
-	const current = data ? (JSON.parse(data) as LocalValidatorEntriesData) : null
-	const currentEra = current?.era
-
-	if (currentEra && currentEra !== era) {
-		localStorage.removeItem(`${network}_validators`)
-	}
-
-	return currentEra === era ? current : null
-}
-
-// Set local validator entries data for an era
-export const setLocalEraValidators = (
-	network: NetworkId,
-	era: string,
-	entries: Validator[],
-) => {
-	localStorage.setItem(
-		`${network}_validators`,
-		JSON.stringify({
-			era,
-			entries,
-		}),
-	)
 }

--- a/packages/app-staking/src/contexts/Validators/ValidatorEntries/defaults.ts
+++ b/packages/app-staking/src/contexts/Validators/ValidatorEntries/defaults.ts
@@ -1,10 +1,6 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-export const defaultValidatorsData = {
-	entries: [],
-}
-
 export const defaultAverageEraValidatorReward = {
 	days: 0,
 	reward: 0n,

--- a/packages/app-staking/src/contexts/Validators/ValidatorEntries/index.tsx
+++ b/packages/app-staking/src/contexts/Validators/ValidatorEntries/index.tsx
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { createSafeContext, useEffectIgnoreInitial } from '@w3ux/hooks'
-import type { Sync } from '@w3ux/types'
-import { shuffle } from '@w3ux/utils'
-import { PerbillMultiplier } from 'consts'
-import { getPeopleChainId } from 'consts/util'
 import { useEraStakers } from 'contexts/EraStakers'
+import { useValidatorRecords } from 'data-gate'
 import {
 	countValidatorRanks,
 	getValidatorRank as getValidatorRankBus,
@@ -15,192 +12,95 @@ import { useApi } from 'hooks/useApi'
 import { useErasPerDay } from 'hooks/useErasPerDay'
 import { useNetwork } from 'hooks/useNetwork'
 import { usePlugins } from 'hooks/usePlugins'
-import { fetchIdentityCache, fetchValidatorStats } from 'plugin-staking-api'
+import { fetchValidatorStats } from 'plugin-staking-api'
 import type { ActiveValidatorRank } from 'plugin-staking-api/types'
-import type { ReactNode } from 'react'
-import { useEffect, useState } from 'react'
-import type { IdentityOf, SuperIdentity, Validator } from 'types'
 import {
-	formatIdentities,
-	formatIdentitiesFromCache,
-	formatSuperIdentities,
-	formatSuperIdentitiesFromCache,
-	perbillToPercent,
-} from 'utils'
-import type {
-	ValidatorAddresses,
-	ValidatorListEntry,
-	Validators,
-	ValidatorsContextInterface,
-} from '../types'
-import {
-	getActivityTier,
-	getLocalEraValidators,
-	setLocalEraValidators,
-} from '../Utils'
-import {
-	defaultAverageEraValidatorReward,
-	defaultValidatorsData,
-} from './defaults'
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react'
+import type { Validator } from 'types'
+import type { ValidatorListEntry, ValidatorsContextInterface } from '../types'
+import { getActivityTier } from '../Utils'
+import { defaultAverageEraValidatorReward } from './defaults'
 
-export const [ValidatorsContext, useValidators] =
-	createSafeContext<ValidatorsContextInterface>()
+type ValidatorSubscription = { addresses: string[]; all: boolean }
+type Context = ValidatorsContextInterface & {
+	registerValidators: (subscription: ValidatorSubscription) => () => void
+}
+export const [ValidatorsContext, useValidatorsContext] =
+	createSafeContext<Context>()
+
+// Only mounted address/list consumers request data. Metric-only readers start no entries query.
+export const useValidators = (addresses: string[] = [], all = false) => {
+	const context = useValidatorsContext()
+	const key = JSON.stringify([...new Set(addresses)].sort())
+	useEffect(() => {
+		if (all || key !== '[]')
+			return context.registerValidators({ addresses: JSON.parse(key), all })
+	}, [context.registerValidators, key, all])
+	return context
+}
 
 export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
-	const { activeEra } = useApi()
+	const { activeEra, isReady, serviceApi, getConsts } = useApi()
 	const { network } = useNetwork()
 	const { pluginEnabled } = usePlugins()
 	const { validatorOverviews } = useEraStakers()
 	const { erasPerDay, maxSupportedDays } = useErasPerDay()
-	const { isReady, serviceApi, getConsts, getApiStatus } = useApi()
 
 	const { historyDepth } = getConsts(network)
+	const [validatorSubscriptions, setValidatorSubscriptions] = useState(
+		new Map<symbol, ValidatorSubscription>(),
+	)
 
-	// Store validator entries and sync status
-	const [validators, setValidators] = useState<Validators>({
-		status: 'unsynced',
-		validators: [],
-	})
-	// Setter for validator status
-	const setValidatorsFetched = (status: Sync) =>
-		setValidators({ ...validators, status })
-
-	// Getter for validator entries
-	const getValidators = () => validators.validators
-
-	// Store validator identity data
-	const [validatorIdentities, setValidatorIdentities] = useState<
-		Record<string, IdentityOf>
-	>({})
-
-	// Store validator super identity data
-	const [validatorSupers, setValidatorSupers] = useState<
-		Record<string, SuperIdentity>
-	>({})
-
-	// Stores the average reward rate
-	const [avgRewardRate, setAvgRewardRate] = useState<number>(0)
-
-	// Stores active validator ranks
+	const registerValidators = useCallback(
+		(subscription: ValidatorSubscription) => {
+			const id = Symbol()
+			setValidatorSubscriptions((current) =>
+				new Map(current).set(id, subscription),
+			)
+			return () =>
+				setValidatorSubscriptions((current) => {
+					const next = new Map(current)
+					next.delete(id)
+					return next
+				})
+		},
+		[],
+	)
+	const requested = useMemo(
+		() =>
+			[
+				...new Set(
+					[...validatorSubscriptions.values()].flatMap(
+						({ addresses }) => addresses,
+					),
+				),
+			].sort(),
+		[validatorSubscriptions],
+	)
+	const all = [...validatorSubscriptions.values()].some(
+		(subscription) => subscription.all,
+	)
+	const records = useValidatorRecords(requested, all)
+	const getValidators = () => records.entries ?? []
+	const validatorIdentities = records.data?.identities ?? {}
+	const validatorSupers = records.data?.supers ?? {}
+	const formatWithPrefs = (addresses: string[]): Validator[] =>
+		addresses.map((address) => ({
+			address,
+			prefs: records.data?.prefs[address] ?? null,
+		}))
+	const [avgRewardRate, setAvgRewardRate] = useState(0)
 	const [activeValidatorRanks, setActiveValidatorRanks] = useState<
 		ActiveValidatorRank[]
 	>([])
-
-	// Stores the average era validator reward
-	const [averageEraValidatorReward, setAverageEraValidatorReward] = useState<{
-		days: number
-		reward: bigint
-	}>(defaultAverageEraValidatorReward)
-
-	// Fetch validator entries and format the returning data
-	const getValidatorEntries = async () => {
-		if (!isReady) {
-			return defaultValidatorsData
-		}
-		const result = await serviceApi.query.validatorEntries()
-		const entries: Validator[] = []
-
-		result.forEach(([address, { commission, blocked }]) => {
-			const commissionUnit = commission / PerbillMultiplier
-			entries.push({
-				address,
-				prefs: {
-					commission: Number(commissionUnit.toFixed(2)),
-					blocked,
-				},
-			})
-		})
-		return { entries }
-	}
-
-	// Fetches and formats the active validator set, and derives metrics from the result
-	const fetchValidators = async () => {
-		if (!isReady || validators.status !== 'unsynced') {
-			return
-		}
-		setValidatorsFetched('syncing')
-
-		// If local validator entries exist for the current era, store these values in state. Otherwise,
-		// fetch entries from API
-		const localEraValidators = getLocalEraValidators(
-			network,
-			activeEra.index.toString(),
-		)
-
-		// The validator entries for the current active era
-		let validatorEntries: Validator[] = []
-		if (localEraValidators) {
-			validatorEntries = localEraValidators.entries
-		} else {
-			const result = await getValidatorEntries()
-			validatorEntries = result.entries
-		}
-
-		// Set entries data for the era to local storage
-		setLocalEraValidators(network, activeEra.index.toString(), validatorEntries)
-
-		// NOTE: validators are shuffled before committed to state
-		setValidators({ status: 'synced', validators: shuffle(validatorEntries) })
-
-		const addresses = validatorEntries.map(({ address }) => address)
-
-		// Fetch identities - use GraphQL if staking API is enabled, otherwise use dedot API
-		if (pluginEnabled('staking_api')) {
-			const { identityCache } = await fetchIdentityCache(network, addresses)
-			setValidatorIdentities({
-				...formatIdentitiesFromCache(addresses, identityCache),
-			})
-			setValidatorSupers({ ...formatSuperIdentitiesFromCache(identityCache) })
-		} else {
-			const [identities, supers] = await Promise.all([
-				serviceApi.query.identityOfMulti(addresses),
-				serviceApi.query.superOfMulti(addresses),
-			])
-			setValidatorIdentities({ ...formatIdentities(addresses, identities) })
-			setValidatorSupers({ ...formatSuperIdentities(supers) })
-		}
-	}
-
-	// Fetches prefs for a list of validators
-	const fetchValidatorPrefs = async (addresses: ValidatorAddresses) => {
-		if (!addresses.length) {
-			return null
-		}
-
-		const v: string[] = []
-		const vMulti: string[] = []
-		for (const { address } of addresses) {
-			v.push(address)
-			vMulti.push(address)
-		}
-
-		const resultsMulti = await serviceApi.query.validatorsMulti(vMulti)
-		const formatted: Validator[] = []
-		for (let i = 0; i < resultsMulti.length; i++) {
-			const prefs = resultsMulti[i]
-
-			if (prefs) {
-				formatted.push({
-					address: v[i],
-					prefs: {
-						commission: Number(perbillToPercent(prefs.commission).toString()),
-						blocked: prefs.blocked,
-					},
-				})
-			}
-		}
-		return formatted
-	}
-
-	// Formats a list of addresses with validator preferences
-	const formatWithPrefs = (addresses: string[]) =>
-		addresses.map((address) => ({
-			address,
-			prefs: getValidators().find((v) => v.address === address)?.prefs || {
-				blocked: false,
-				commission: 0,
-			},
-		}))
+	const [averageEraValidatorReward, setAverageEraValidatorReward] = useState(
+		defaultAverageEraValidatorReward,
+	)
 
 	// Inject status into validator entries
 	const injectValidatorListData = (
@@ -215,11 +115,7 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
 
 	// Gets a validator's total stake, if any
 	const getValidatorTotalStake = (address: string): bigint => {
-		const entry = getValidators().find((v) => v.address === address)
-		if (!entry) {
-			return 0n
-		}
-		const inEra = validatorOverviews?.get(entry.address)
+		const inEra = validatorOverviews?.get(address)
 		if (!inEra) {
 			return 0n
 		}
@@ -292,16 +188,6 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
 	const getValidatorActivityTier = (validator: string) =>
 		getActivityTier(getValidatorRank(validator), getValidatorRankTotal())
 
-	// Reset validator state data on network change
-	useEffectIgnoreInitial(() => {
-		setValidators({
-			status: 'unsynced',
-			validators: [],
-		})
-		setValidatorIdentities({})
-		setValidatorSupers({})
-	}, [network])
-
 	// Refetch staking API validator stats when network or era changes so APY does not remain stale at
 	// the initial default value.
 	useEffect(() => {
@@ -310,24 +196,9 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
 		}
 	}, [network, activeEra.index, pluginEnabled('staking_api')])
 
-	// Fetch validators and era reward points when fetched status changes
-	useEffect(() => {
-		if (isReady && activeEra.index > 0) {
-			fetchValidators()
-		}
-	}, [
-		validators.status,
-		isReady,
-		getApiStatus(getPeopleChainId(network)),
-		activeEra,
-	])
-
 	// Mark unsynced and fetch session validators and average reward when activeEra changes
 	useEffectIgnoreInitial(() => {
 		if (isReady && activeEra.index > 0) {
-			if (validators.status === 'synced') {
-				setValidatorsFetched('unsynced')
-			}
 			if (!pluginEnabled('staking_api') || avgRewardRate === 0) {
 				getAverageEraValidatorReward()
 			}
@@ -337,12 +208,21 @@ export const ValidatorsProvider = ({ children }: { children: ReactNode }) => {
 	return (
 		<ValidatorsContext.Provider
 			value={{
-				fetchValidatorPrefs,
+				registerValidators,
+				validatorsError: records.error,
+				retryValidators: () => {
+					void records.refetch()
+				},
+				getValidatorPrefs: (address) => records.data?.prefs[address],
 				injectValidatorListData,
 				getValidators,
 				validatorIdentities,
 				validatorSupers,
-				validatorsFetched: validators.status,
+				validatorsFetched: records.loading
+					? 'syncing'
+					: records.error
+						? 'unsynced'
+						: 'synced',
 				avgRewardRate,
 				averageEraValidatorReward,
 				formatWithPrefs,

--- a/packages/app-staking/src/contexts/Validators/types.ts
+++ b/packages/app-staking/src/contexts/Validators/types.ts
@@ -36,20 +36,6 @@ export interface AverageEraValidatorReward {
 	days: number
 	reward: bigint
 }
-export interface Validators {
-	status: Sync
-	validators: Validator[]
-}
-
-export type ValidatorAddresses = {
-	address: string
-}[]
-
-export interface LocalValidatorEntriesData {
-	era: string
-	entries: Validator[]
-}
-
 export type ValidatorListEntry = Validator & {
 	validatorStatus: ValidatorStatus
 }

--- a/packages/app-staking/src/contexts/Validators/types.ts
+++ b/packages/app-staking/src/contexts/Validators/types.ts
@@ -2,12 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { Sync } from '@w3ux/types'
-import type { AnyJson, IdentityOf, Validator, ValidatorStatus } from 'types'
+import type {
+	AnyJson,
+	IdentityOf,
+	Validator,
+	ValidatorPrefs,
+	ValidatorStatus,
+} from 'types'
 
 export type ValidatorActivityTier = 'belowBaseline' | 'good' | 'notRated'
 
 export interface ValidatorsContextInterface {
-	fetchValidatorPrefs: (a: ValidatorAddresses) => Promise<Validator[] | null>
+	validatorsError: Error | null
+	retryValidators: () => void
+	getValidatorPrefs: (address: string) => ValidatorPrefs | null | undefined
 	injectValidatorListData: (entries: Validator[]) => ValidatorListEntry[]
 	getValidators: () => Validator[]
 	validatorIdentities: Record<string, IdentityOf>

--- a/packages/app-staking/src/hooks/useFetchMethods/index.tsx
+++ b/packages/app-staking/src/hooks/useFetchMethods/index.tsx
@@ -10,6 +10,7 @@ import { useNetwork } from 'hooks/useNetwork'
 import { useValidatorFilters } from 'hooks/useValidatorFilters'
 import type { AddNominationsType } from 'library/GenerateNominations/types'
 import {
+	fetchBasicValidatorCandidates,
 	fetchOptimalValidatorBatch,
 	fetchSanitizeNomineeCandidates,
 	fetchValidatorCandidateBatch,
@@ -25,7 +26,10 @@ export const useFetchMethods = () => {
 	const { network } = useNetwork()
 	const { applyFilter } = useValidatorFilters()
 	const { favoritesList } = useFavoriteValidators()
-	const { getValidators, isValidatorHighPerformance } = useValidators()
+	const { getValidators, isValidatorHighPerformance } = useValidators(
+		[],
+		!pluginEnabled('staking_api'),
+	)
 	const stakingApiEnabled = pluginEnabled('staking_api')
 	const stakingApiCandidatesEnabled =
 		stakingApiEnabled && StakingApiRetainmentSupportedNetworks.includes(network)
@@ -79,24 +83,18 @@ export const useFetchMethods = () => {
 		const { fetchOptimalValidatorBatch: candidates } =
 			await fetchOptimalValidatorBatch({ network })
 
-		return shuffle([...candidates]).slice(0, MAX_OPTIMAL_VALIDATORS)
+		const { sanitizeNomineeCandidates } = await fetchSanitizeNomineeCandidates(
+			network,
+			shuffle([...candidates]).slice(0, MAX_OPTIMAL_VALIDATORS),
+		)
+		return sanitizeNomineeCandidates
 	}
 
 	const fetchOptimal = async () => {
-		const nominations = stakingApiCandidatesEnabled
-			? await fetchStakingApiOptimal()
-			: fetchCurrentOptimal()
-
-		if (!stakingApiEnabled) {
-			return nominations
-		}
-
-		const { sanitizeNomineeCandidates } = await fetchSanitizeNomineeCandidates(
-			network,
-			nominations,
-		)
-
-		return sanitizeNomineeCandidates
+		if (!stakingApiEnabled) return fetchCurrentOptimal()
+		return stakingApiCandidatesEnabled
+			? fetchStakingApiOptimal()
+			: fetchBasicValidatorCandidates(network, 'OPTIMAL')
 	}
 
 	const fetchCandidate = async (
@@ -139,8 +137,25 @@ export const useFetchMethods = () => {
 		return candidate ? [...nominations, candidate] : nominations
 	}
 
+	const appendApiCandidate = async (
+		nominations: Validator[],
+		strategy: 'ACTIVE' | 'RANDOM' | 'HIGH_ACTIVITY',
+	) => {
+		const [candidate] = await fetchBasicValidatorCandidates(
+			network,
+			strategy,
+			nominations.map(({ address }) => address),
+		)
+		return candidate ? [...nominations, candidate] : nominations
+	}
+
 	const addActiveValidator = (nominations: Validator[]) =>
-		appendRandomCandidate(nominations, available(nominations).activeValidators)
+		stakingApiEnabled
+			? appendApiCandidate(nominations, 'ACTIVE')
+			: appendRandomCandidate(
+					nominations,
+					available(nominations).activeValidators,
+				)
 
 	const addHighPerformanceValidator = async (nominations: Validator[]) => {
 		if (stakingApiCandidatesEnabled) {
@@ -148,6 +163,8 @@ export const useFetchMethods = () => {
 			return validator ? [...nominations, validator] : nominations
 		}
 
+		if (stakingApiEnabled)
+			return appendApiCandidate(nominations, 'HIGH_ACTIVITY')
 		return appendRandomCandidate(
 			nominations,
 			available(nominations).highPerformance,
@@ -155,7 +172,12 @@ export const useFetchMethods = () => {
 	}
 
 	const addRandomValidator = (nominations: Validator[]) =>
-		appendRandomCandidate(nominations, available(nominations).randomValidators)
+		stakingApiEnabled
+			? appendApiCandidate(nominations, 'RANDOM')
+			: appendRandomCandidate(
+					nominations,
+					available(nominations).randomValidators,
+				)
 
 	return {
 		fetch,

--- a/packages/app-staking/src/hooks/useNominationWarnings/index.ts
+++ b/packages/app-staking/src/hooks/useNominationWarnings/index.ts
@@ -30,7 +30,6 @@ export const useNominationWarnings = () => {
 	const { erasPerDay } = useErasPerDay()
 	const { getNominations } = useBalances()
 	const { openCanvas } = useOverlay().canvas
-	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { isReadOnlyAccount } = useImportedAccounts()
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
@@ -49,6 +48,11 @@ export const useNominationWarnings = () => {
 	const forPool = effectiveBondFor === 'pool'
 
 	// Get the nominations for the resolved staking type.
+	const { formatWithPrefs } = useValidators(
+		forPool
+			? (activePoolNominations?.targets ?? [])
+			: getNominations(activeAddress),
+	)
 	const nominations = formatWithPrefs(
 		forPool
 			? (activePoolNominations?.targets ?? [])

--- a/packages/app-staking/src/hooks/useQuickActions/index.tsx
+++ b/packages/app-staking/src/hooks/useQuickActions/index.tsx
@@ -40,7 +40,6 @@ export const useQuickActions = () => {
 	const { unclaimedRewards } = usePayouts()
 	const { openCanvas } = useOverlay().canvas
 	const { activeAddress } = useActiveAccount()
-	const { formatWithPrefs } = useValidators()
 	const { getNominations, getPendingPoolRewards } = useBalances()
 	const {
 		activePool,
@@ -52,6 +51,10 @@ export const useQuickActions = () => {
 	const { hasEnoughToNominate } = useAccountBalances(activeAddress)
 	const { setNominatorSetup, generateOptimalSetup } = useNominatorSetups()
 
+	const { formatWithPrefs } = useValidators([
+		...getNominations(activeAddress),
+		...(activePoolNominations?.targets ?? []),
+	])
 	const pendingRewards = getPendingPoolRewards(activeAddress)
 
 	const baseQuickActions: Record<string, ButtonQuickActionProps> = {

--- a/packages/app-staking/src/hooks/useValidatorFromUrl/index.tsx
+++ b/packages/app-staking/src/hooks/useValidatorFromUrl/index.tsx
@@ -4,7 +4,6 @@
 import { extractUrlValue } from '@w3ux/utils'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { emitNotification } from 'global-bus'
-import { useApi } from 'hooks/useApi'
 import { useUi } from 'hooks/useUi'
 import { getIdentityDisplay } from 'library/List/Utils'
 import { useEffect, useRef } from 'react'
@@ -14,42 +13,32 @@ import { useOverlay } from 'ui-overlay'
 
 export const useValidatorFromUrl = () => {
 	const { t } = useTranslation('app')
-	const { isReady } = useApi()
 	const { search } = useLocation()
+	const validator = extractUrlValue('v')
 	const { openCanvas, setCanvasConfig, status } = useOverlay().canvas
 	const { setAdvancedMode } = useUi()
 	const {
-		getValidators,
+		getValidatorPrefs,
+		validatorsError,
 		validatorIdentities,
 		validatorSupers,
 		validatorsFetched,
-	} = useValidators()
+	} = useValidators(validator ? [validator] : [])
 
 	// Track the validator address that was last opened from a URL param
 	const openedRef = useRef<string | null>(null)
 
 	useEffect(() => {
-		if (!isReady || validatorsFetched !== 'synced') {
-			return
-		}
-
-		// Wait until identity data has been fetched. Identities load after
-		// validatorsFetched becomes 'synced', so we need to wait for them
 		if (
-			!Object.keys(validatorIdentities).length &&
-			!Object.keys(validatorSupers).length
-		) {
+			!validator ||
+			validator === openedRef.current ||
+			validatorsError ||
+			validatorsFetched !== 'synced'
+		)
 			return
-		}
-
-		const validator = extractUrlValue('v')
-		if (!validator || validator === openedRef.current) {
-			return
-		}
-
-		// Check if the address belongs to a known validator
-		const allValidators = getValidators()
-		const exists = allValidators.some((v) => v.address === validator)
+		const prefs = getValidatorPrefs(validator)
+		if (prefs === undefined) return
+		const exists = prefs !== null
 
 		if (!exists) {
 			emitNotification({
@@ -87,7 +76,9 @@ export const useValidatorFromUrl = () => {
 			openCanvas(config)
 		}
 	}, [
-		isReady,
+		validator,
+		validatorsError,
+		getValidatorPrefs,
 		validatorsFetched,
 		validatorIdentities,
 		validatorSupers,

--- a/packages/app-staking/src/library/GenerateNominations/Prompts/SearchValidators.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/Prompts/SearchValidators.tsx
@@ -5,12 +5,13 @@ import { MaxNominations } from 'consts'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { emitNotification } from 'global-bus'
 import { useNetwork } from 'hooks/useNetwork'
+import { usePlugins } from 'hooks/usePlugins'
 import { SearchInput } from 'library/List/SearchInput'
 import { Identity } from 'library/ListItem/Labels/Identity'
 import { FooterWrapper, PromptListItem } from 'library/Prompt/Wrappers'
 import { StyledSlider } from 'library/StyledSlider'
 import { fetchSearchValidators } from 'plugin-staking-api'
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { Validator } from 'types'
 import { ButtonPrimary } from 'ui-buttons'
@@ -24,7 +25,16 @@ export const SearchValidators = ({ callback, nominations }: PromptProps) => {
 	const { t } = useTranslation()
 	const { closePrompt } = usePrompt()
 	const { network } = useNetwork()
-	const { getValidators, validatorsFetched } = useValidators()
+	const { pluginEnabled } = usePlugins()
+	const api = pluginEnabled('staking_api')
+	const {
+		getValidators,
+		validatorsFetched,
+		validatorIdentities,
+		validatorSupers,
+		validatorsError,
+	} = useValidators([], !api)
+	const [searchError, setSearchError] = useState(false)
 
 	// Number of validators to show by default when no search term is entered
 	const defaultDisplayLimit = 50
@@ -44,48 +54,44 @@ export const SearchValidators = ({ callback, nominations }: PromptProps) => {
 	// Store commission filter value (default 10%)
 	const [maxCommission, setMaxCommission] = useState<number>(10)
 
-	// Debounced search function
-	const debouncedSearch = useCallback(
-		async (term: string) => {
-			if (term.length === 0) {
-				setSearchResults([])
-				setIsSearching(false)
-				return
-			}
-
-			setIsSearching(true)
-			try {
-				const result = await fetchSearchValidators(network, term)
-				if (result.searchValidators.validators.length > 0) {
-					const transformedValidators: Validator[] =
-						result.searchValidators.validators.map((validator) => ({
-							address: validator.address,
-							prefs: {
-								commission: validator.commission,
-								blocked: validator.blocked,
-							},
-						}))
-					setSearchResults(transformedValidators)
-				} else {
-					setSearchResults([])
-				}
-			} catch {
-				setSearchResults([])
-			} finally {
-				setIsSearching(false)
-			}
-		},
-		[network],
-	)
-
-	// Debounce effect
+	// Cancel stale results on search, network, and source changes.
 	useEffect(() => {
-		const timeoutId = setTimeout(() => {
-			debouncedSearch(searchTerm)
+		if (!api) {
+			setIsSearching(false)
+			setSearchError(false)
+			return
+		}
+		const controller = new AbortController()
+		setIsSearching(true)
+		setSearchError(false)
+		setSearchResults([])
+		const timeout = setTimeout(async () => {
+			try {
+				const result = await fetchSearchValidators(network, searchTerm, {
+					maxCommission,
+					limit: defaultDisplayLimit,
+					signal: controller.signal,
+				})
+				if (!controller.signal.aborted)
+					setSearchResults(
+						result.searchValidators.validators.map(
+							({ address, commission, blocked }) => ({
+								address,
+								prefs: { commission, blocked },
+							}),
+						),
+					)
+			} catch {
+				if (!controller.signal.aborted) setSearchError(true)
+			} finally {
+				if (!controller.signal.aborted) setIsSearching(false)
+			}
 		}, 300)
-
-		return () => clearTimeout(timeoutId)
-	}, [searchTerm, debouncedSearch])
+		return () => {
+			controller.abort()
+			clearTimeout(timeout)
+		}
+	}, [api, network, searchTerm, maxCommission])
 
 	const addToSelected = (item: Validator) => {
 		setSelected((prev) =>
@@ -108,24 +114,26 @@ export const SearchValidators = ({ callback, nominations }: PromptProps) => {
 		setSearchTerm(value)
 	}
 
-	// Filter search results by commission
-	const filteredSearchResults = searchResults.filter(
-		(validator) => (validator.prefs?.commission || 0) <= maxCommission,
-	)
-
-	const hasSearchTerm = searchTerm.length > 0
-	const validatorsSynced = validatorsFetched === 'synced'
-
-	// When no search term is entered, show a capped, commission-filtered slice of
-	// the full validator list (already loaded client-side via useValidators)
-	const defaultValidators = getValidators()
-		.filter((validator) => (validator.prefs?.commission || 0) <= maxCommission)
+	const hasSearchTerm = searchTerm.trim().length > 0
+	const validatorsSynced = api || validatorsFetched === 'synced'
+	const term = searchTerm.trim().toLowerCase()
+	const nodeResults = getValidators()
+		.filter(({ address, prefs }) => {
+			const display = validatorIdentities[address]?.info.display.value || ''
+			const parent =
+				validatorSupers[address]?.superOf?.identity?.info.display.value || ''
+			return (
+				prefs &&
+				prefs.commission <= maxCommission &&
+				(!term ||
+					`${address} ${display} ${parent}`.toLowerCase().includes(term))
+			)
+		})
 		.slice(0, defaultDisplayLimit)
-
-	// The validators to render in the list area
-	const displayValidators = hasSearchTerm
-		? filteredSearchResults
-		: defaultValidators
+	const displayValidators = api ? searchResults : nodeResults
+	const filteredSearchResults = displayValidators
+	const defaultValidators = displayValidators
+	const error = api ? searchError : !!validatorsError
 
 	return (
 		<>
@@ -178,7 +186,11 @@ export const SearchValidators = ({ callback, nominations }: PromptProps) => {
 										? `${t('validatorSearch.searchResults', { ns: 'app' })} (${filteredSearchResults.length})`
 										: `${t('validators', { ns: 'app' })} (${defaultValidators.length})`}
 							</SearchList.SearchHeader>
-							{isSearching || (!hasSearchTerm && !validatorsSynced) ? (
+							{error ? (
+								<SearchList.Loading
+									message={t('errorUnknown', { ns: 'app' })}
+								/>
+							) : isSearching || !validatorsSynced ? (
 								<SearchList.Loading
 									message={`${t(hasSearchTerm ? 'validatorSearch.searching' : 'waiting', { ns: 'app' })}...`}
 								/>

--- a/packages/app-staking/src/library/GenerateNominations/useNominationControls.tsx
+++ b/packages/app-staking/src/library/GenerateNominations/useNominationControls.tsx
@@ -5,13 +5,15 @@ import { faMagnifyingGlass, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { MaxNominations } from 'consts'
 import { PolkadotKnownValidators } from 'consts/validators'
 import { useManageNominations } from 'contexts/ManageNominations'
+import { emitNotification } from 'global-bus'
 import { useFavoriteValidators } from 'hooks/useFavoriteValidators'
 import { useFetchMethods } from 'hooks/useFetchMethods'
+import { useNetwork } from 'hooks/useNetwork'
 import { useNominationHealth } from 'hooks/useNominationHealth'
 import { useUi } from 'hooks/useUi'
 import { Confirm } from 'library/Prompt/Confirm'
 import type { ValidatorCandidateStrategy } from 'plugin-staking-api/types'
-import { type ComponentType, useState } from 'react'
+import { type ComponentType, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { AnyFunction, Validator } from 'types'
 import { usePrompt } from 'ui-overlay'
@@ -51,6 +53,15 @@ export const useNominationControls = ({
 
 	// Track whether a candidate is being fetched asynchronously.
 	const [candidateFetching, setCandidateFetching] = useState(false)
+	const { network } = useNetwork()
+	const scope = JSON.stringify([network, stakingApiEnabled, nominations])
+	const scopeRef = useRef<string | null>(scope)
+	useEffect(() => {
+		scopeRef.current = scope
+		return () => {
+			scopeRef.current = null
+		}
+	}, [scope])
 
 	// Keep local and externally supplied nomination state in sync.
 	const updateNominations = (nextNominations: Validator[]) => {
@@ -59,19 +70,29 @@ export const useNominationControls = ({
 	}
 
 	const addNominationByType = async (type: AddNominationsType) => {
-		if (!canManageNominations || !method || candidateFetching) {
+		if (
+			!canManageNominations ||
+			!method ||
+			candidateFetching ||
+			nominations.length >= MaxNominations
+		) {
 			return
 		}
 
-		// Retainment-backed performance candidates require an asynchronous lookup.
-		const trackCandidateRequest =
-			type === 'High Performance Validator' && retainmentStatsEnabled
+		// All API candidate strategies are asynchronous.
+		const trackCandidateRequest = stakingApiEnabled
 		if (trackCandidateRequest) {
 			setCandidateFetching(true)
 		}
 
 		try {
-			updateNominations(await addNomination(nominations, type))
+			const next = await addNomination(nominations, type)
+			if (scopeRef.current === scope) updateNominations(next)
+		} catch {
+			emitNotification({
+				title: t('errorUnknown', { ns: 'app' }),
+				subtitle: t('tryAgain', { ns: 'app' }),
+			})
 		} finally {
 			if (trackCandidateRequest) {
 				setCandidateFetching(false)
@@ -98,9 +119,14 @@ export const useNominationControls = ({
 			const alreadyNominated = nominations.some(
 				({ address }) => address === candidate?.address,
 			)
-			if (candidate && !alreadyNominated) {
+			if (scopeRef.current === scope && candidate && !alreadyNominated) {
 				updateNominations([...nominations, candidate])
 			}
+		} catch {
+			emitNotification({
+				title: t('errorUnknown', { ns: 'app' }),
+				subtitle: t('tryAgain', { ns: 'app' }),
+			})
 		} finally {
 			setCandidateFetching(false)
 		}
@@ -139,7 +165,7 @@ export const useNominationControls = ({
 			nominations.some(({ address }) => address === knownAddress),
 	)
 	const availableNominations =
-		retainmentStatsEnabled || !canManageNominations
+		stakingApiEnabled || !canManageNominations
 			? null
 			: availableToNominate(nominations)
 
@@ -195,14 +221,18 @@ export const useNominationControls = ({
 				onClick: () => addNominationByType('Active Validator'),
 				icon: faPlus,
 				isDisabled: () =>
-					addDisabled || !availableNominations?.activeValidators.length,
+					candidateDisabled ||
+					(!stakingApiEnabled &&
+						!availableNominations?.activeValidators.length),
 			},
 			{
 				title: t('randomValidator', { ns: 'app' }),
 				onClick: () => addNominationByType('Random Validator'),
 				icon: faPlus,
 				isDisabled: () =>
-					addDisabled || !availableNominations?.randomValidators.length,
+					candidateDisabled ||
+					(!stakingApiEnabled &&
+						!availableNominations?.randomValidators.length),
 			},
 		)
 	}
@@ -213,8 +243,7 @@ export const useNominationControls = ({
 		icon: faPlus,
 		isDisabled: () =>
 			candidateDisabled ||
-			(!retainmentStatsEnabled &&
-				!availableNominations?.highPerformance.length),
+			(!stakingApiEnabled && !availableNominations?.highPerformance.length),
 	})
 
 	if (stakingApiEnabled) {

--- a/packages/app-staking/src/library/GenerateNominations/useNominationSync.ts
+++ b/packages/app-staking/src/library/GenerateNominations/useNominationSync.ts
@@ -5,8 +5,12 @@ import { useActiveAccount } from '@polkadot-cloud/connect'
 import { useEraStakers } from 'contexts/EraStakers'
 import { useManageNominations } from 'contexts/ManageNominations'
 import { useValidators } from 'contexts/Validators/ValidatorEntries'
+import { emitNotification } from 'global-bus'
 import { useApi } from 'hooks/useApi'
+import { useNetwork } from 'hooks/useNetwork'
+import { usePlugins } from 'hooks/usePlugins'
 import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { Validator } from 'types'
 
 interface UseNominationSyncProps {
@@ -28,13 +32,25 @@ export const useNominationSync = ({
 		setMethod,
 		setNominations,
 	} = useManageNominations()
+	const { t } = useTranslation('app')
 	const { isReady } = useApi()
+	const { pluginEnabled } = usePlugins()
+	const api = pluginEnabled('staking_api')
 	const { activeAddress } = useActiveAccount()
 	const { validatorOverviews } = useEraStakers()
 	const { getValidators, validatorsFetched } = useValidators()
 
 	// Track whether a fetch is already in progress to avoid duplicate requests.
 	const fetchingRef = useRef(false)
+	const { network } = useNetwork()
+	const scope = `${network}:${activeAddress}:${api}`
+	const scopeRef = useRef<string | null>(scope)
+	useEffect(() => {
+		scopeRef.current = scope
+		return () => {
+			scopeRef.current = null
+		}
+	}, [scope])
 
 	// Reset only when the account or initial nominations change, not during edits.
 	useEffect(() => {
@@ -50,10 +66,11 @@ export const useNominationSync = ({
 	// Generate only after validator and era data are ready, with one request in flight.
 	useEffect(() => {
 		const dataReady =
-			isReady &&
-			Boolean(getValidators()?.length) &&
-			!!validatorOverviews &&
-			validatorsFetched === 'synced'
+			api ||
+			(isReady &&
+				Boolean(getValidators()?.length) &&
+				!!validatorOverviews &&
+				validatorsFetched === 'synced')
 
 		if (!fetching || !method || !dataReady || fetchingRef.current) {
 			return
@@ -62,7 +79,14 @@ export const useNominationSync = ({
 		fetchingRef.current = true
 		const generateNominations = async () => {
 			try {
-				updateNominations(await fetchNominations(method))
+				const next = await fetchNominations(method)
+				if (scopeRef.current === scope) updateNominations(next)
+			} catch {
+				if (scopeRef.current === scope)
+					emitNotification({
+						title: t('errorUnknown'),
+						subtitle: t('tryAgain'),
+					})
 			} finally {
 				setFetching(false)
 				fetchingRef.current = false

--- a/packages/app-staking/src/library/List/EraPointsGraph/CurrentEraPoints.tsx
+++ b/packages/app-staking/src/library/List/EraPointsGraph/CurrentEraPoints.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import {
 	eraRewardPoints$,
 	getEraRewardPoints,
@@ -28,7 +27,6 @@ export const CurrentEraPoints = ({
 }: CurrentEraPointsProps) => {
 	const { t } = useTranslation()
 	const { isReady, activeEra } = useApi()
-	const { validatorsFetched } = useValidators()
 	const { setTooltipTextAndOpen } = useTooltipActions()
 
 	// Store era reward points for the current address
@@ -49,7 +47,7 @@ export const CurrentEraPoints = ({
 		)
 		return Array(7).fill(Object.values(normalisedPoints)[0])
 	}, [activeEra.index, eraPoints, eraHigh])
-	const syncing = !isReady || !validatorsFetched || eraHigh <= 1
+	const syncing = !isReady || eraHigh <= 1
 	const tooltipText = t('eraRewardPoints', {
 		ns: 'app',
 		points: eraPoints.toFormat(),

--- a/packages/app-staking/src/library/List/EraPointsGraph/HistoricalEraPoints.tsx
+++ b/packages/app-staking/src/library/List/EraPointsGraph/HistoricalEraPoints.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import BigNumber from 'bignumber.js'
-import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useApi } from 'hooks/useApi'
 import { useMemo } from 'react'
 import { Graph } from 'ui-core/list'
@@ -17,7 +16,6 @@ export const HistoricalEraPoints = ({
 	syncing: syncingOverride,
 }: EraPointsHistoricalProps) => {
 	const { isReady } = useApi()
-	const { validatorsFetched } = useValidators()
 
 	const prefilledPoints = useMemo(() => {
 		const high = eraPoints.reduce<bigint>((max, { points }) => {
@@ -33,8 +31,7 @@ export const HistoricalEraPoints = ({
 		)
 		return prefillEraPoints(Object.values(normalisedPoints))
 	}, [eraPoints])
-	const syncing =
-		syncingOverride ?? (!isReady || !eraPoints.length || !validatorsFetched)
+	const syncing = syncingOverride ?? (!isReady || !eraPoints.length)
 
 	return (
 		<Graph

--- a/packages/app-staking/src/library/ListItem/Labels/Identity.tsx
+++ b/packages/app-staking/src/library/ListItem/Labels/Identity.tsx
@@ -14,7 +14,7 @@ export const Identity = ({
 	size = 'default',
 }: IdentityProps) => {
 	const { validatorIdentities, validatorSupers, validatorsFetched } =
-		useValidators()
+		useValidators(displayOverride === undefined ? [address] : [])
 	const display =
 		displayOverride === undefined
 			? getIdentityDisplay(
@@ -22,7 +22,8 @@ export const Identity = ({
 					validatorSupers[address],
 				).node
 			: displayOverride
-	const identityFetched = displayOverride !== undefined || validatorsFetched
+	const identityFetched =
+		displayOverride !== undefined || validatorsFetched === 'synced'
 	const large = size === 'large'
 	const polkiconSize = large ? '2.75rem' : '2.2rem'
 

--- a/packages/app-staking/src/library/ListItem/types.ts
+++ b/packages/app-staking/src/library/ListItem/types.ts
@@ -33,7 +33,7 @@ export type MoreProps = Outline & {
 	outline?: boolean
 }
 export interface BlockedProps {
-	prefs: ValidatorPrefs
+	prefs: ValidatorPrefs | null
 }
 
 export interface IdentityProps {

--- a/packages/app-staking/src/library/NominationList/BasicItem.tsx
+++ b/packages/app-staking/src/library/NominationList/BasicItem.tsx
@@ -25,8 +25,11 @@ const Basic = ({
 	isNominationPreloading,
 	nominationError,
 }: ItemProps) => {
-	const { validatorIdentities, validatorSupers } = useValidators()
-	const { address, prefs } = validator
+	const { validatorIdentities, validatorSupers, getValidatorPrefs } =
+		useValidators([validator.address])
+	const { address } = validator
+	const resolvedPrefs = getValidatorPrefs(address)
+	const prefs = resolvedPrefs === undefined ? validator.prefs : resolvedPrefs
 	const outline = displayFor === 'canvas'
 
 	return (

--- a/packages/app-staking/src/library/NominationList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/NominationList/DetailedItem.tsx
@@ -50,8 +50,12 @@ export const DetailedItem = ({
 	const { t } = useTranslation('app')
 	const { network } = useNetwork()
 	const retainmentEnabled = useRetainmentStatsEnabled()
-	const { validatorIdentities, validatorSupers } = useValidators()
-	const { address, prefs, validatorStatus } = validator
+	const { validatorIdentities, validatorSupers, getValidatorPrefs } =
+		useValidators([validator.address])
+
+	const { address, validatorStatus } = validator
+	const resolvedPrefs = getValidatorPrefs(address)
+	const prefs = resolvedPrefs === undefined ? validator.prefs : resolvedPrefs
 	const { unit, units } = getStakingChainData(network)
 	const { selfStake, selfStakeMax } = useValidatorSelfStake(address, units)
 	const nominationStatus =
@@ -143,7 +147,7 @@ export const DetailedItem = ({
 				statusLabel={statusLabel}
 				statusValue={totalActiveBacking}
 				unit={unit}
-				validator={validator}
+				validator={{ ...validator, prefs }}
 				warnings={warningBadges}
 			/>
 		)

--- a/packages/app-staking/src/library/Nominations/index.tsx
+++ b/packages/app-staking/src/library/Nominations/index.tsx
@@ -40,7 +40,6 @@ export const Nominations = ({
 	const { isBonding } = useStaking()
 	const { openHelpTooltip } = useHelp()
 	const { getNominations } = useBalances()
-	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { syncing } = useSyncing(['era-stakers'])
 	const retainmentStatsEnabled = useRetainmentStatsEnabled()
@@ -49,6 +48,11 @@ export const Nominations = ({
 	// Determine if pool or nominator.
 	const isPool = bondFor === 'pool'
 
+	const { formatWithPrefs } = useValidators(
+		isPool
+			? (activePoolNominations?.targets ?? [])
+			: getNominations(activeAddress),
+	)
 	// Derive nominations from `bondFor` type.
 	const nominated =
 		bondFor === 'nominator'

--- a/packages/app-staking/src/library/SideMenu/Main.tsx
+++ b/packages/app-staking/src/library/SideMenu/Main.tsx
@@ -38,7 +38,6 @@ export const Main = ({
 	const { pathname } = useLocation()
 	const { inPool } = useActivePool()
 	const { isBonding } = useStaking()
-	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { sideMenuMinimised, advancedMode } = useUi()
 	const { getNominations, getStakingLedger } = useBalances()
@@ -47,10 +46,11 @@ export const Main = ({
 	const { balances, nominatorBalance } = useAccountBalances(activeAddress)
 	const { totalUnlockChunks } = balances.nominator
 
+	const { formatWithPrefs } = useValidators(getNominations(activeAddress))
 	const menuMinimised = sideMenuMinimised && !advancedMode
 	const nominated = formatWithPrefs(getNominations(activeAddress))
 	const fullCommissionNominees = nominated.filter(
-		(nominee) => nominee.prefs.commission === 100,
+		(nominee) => nominee.prefs?.commission === 100,
 	)
 
 	const pages: PageItem[] = getPagesConfig(

--- a/packages/app-staking/src/library/StakingApiValidatorList/Item.tsx
+++ b/packages/app-staking/src/library/StakingApiValidatorList/Item.tsx
@@ -6,6 +6,7 @@ import { getStakingChainData } from 'consts/util'
 import type { ListFormat } from 'contexts/List/types'
 import { getActivityTier } from 'contexts/Validators/Utils'
 import { useNetwork } from 'hooks/useNetwork'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { useHardCapSelfStake } from 'hooks/useStakingMetrics'
 import { CopyAddress } from 'library/ListItem/Buttons/CopyAddress'
 import { FavoriteValidator } from 'library/ListItem/Buttons/FavoriteValidator'
@@ -71,6 +72,7 @@ export const Item = ({
 }: ItemProps) => {
 	const { t } = useTranslation('app')
 	const { network } = useNetwork()
+	const showRetainment = useRetainmentStatsEnabled()
 	const hardCapSelfStake = useHardCapSelfStake()
 	const { unit, units } = getStakingChainData(network)
 	const { address, prefs } = validator
@@ -124,11 +126,14 @@ export const Item = ({
 	if (format === 'row') {
 		return (
 			<ValidatorBar
+				showRetainment={showRetainment}
 				actions={
 					<RowActionsMenu
 						address={address}
 						display={validatorDisplay}
-						onRetainmentHistory={openRetainmentHistory}
+						onRetainmentHistory={
+							showRetainment ? openRetainmentHistory : undefined
+						}
 						retainmentHistoryDisabled={retainmentHistoryDisabled}
 						showFavorite={toggleFavorites}
 						showMetrics
@@ -143,7 +148,7 @@ export const Item = ({
 				isEraPointsPreloading={isEraPointsLoading}
 				isRatePreloading={isRateLoading}
 				isRetainmentPreloading={false}
-				onRetainmentHistory={openRetainmentHistory}
+				onRetainmentHistory={showRetainment ? openRetainmentHistory : undefined}
 				rate={rateAfterCommission}
 				retainmentHistoryDisabled={retainmentHistoryDisabled}
 				retainmentStats={retainmentStats}
@@ -178,17 +183,20 @@ export const Item = ({
 			<ListItem.Action wide>
 				<Metrics address={address} display={validatorDisplay} />
 			</ListItem.Action>
-			<ListItem.Action wide>
-				<RetainmentHistory
-					disabled={retainmentHistoryDisabled}
-					onClick={openRetainmentHistory}
-				/>
-			</ListItem.Action>
+			{showRetainment && (
+				<ListItem.Action wide>
+					<RetainmentHistory
+						disabled={retainmentHistoryDisabled}
+						onClick={openRetainmentHistory}
+					/>
+				</ListItem.Action>
+			)}
 		</ListItem.Actions>
 	)
 
 	return (
 		<ValidatorCard
+			showRetainment={showRetainment}
 			actions={actions}
 			address={address}
 			activitySyncing={false}

--- a/packages/app-staking/src/library/StakingApiValidatorList/index.tsx
+++ b/packages/app-staking/src/library/StakingApiValidatorList/index.tsx
@@ -4,6 +4,7 @@
 import { ListProvider, useList } from 'contexts/List'
 import { useErasPerDay } from 'hooks/useErasPerDay'
 import { useNetwork } from 'hooks/useNetwork'
+import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
 import { FilterHeaderWrapper, List, Wrapper as ListWrapper } from 'library/List'
 import { MotionContainer, MotionItem } from 'library/List/MotionContainer'
 import { Pagination } from 'library/List/Pagination'
@@ -44,6 +45,7 @@ export const StakingApiValidatorListInner = ({
 }: StakingApiValidatorListProps) => {
 	const { t } = useTranslation('app')
 	const { network } = useNetwork()
+	const retainmentEnabled = useRetainmentStatsEnabled()
 	const { erasPerDay } = useErasPerDay()
 	const { listFormat, setListFormat } = useList()
 	const [page, setPage] = useState(1)
@@ -66,7 +68,9 @@ export const StakingApiValidatorListInner = ({
 			network,
 			page,
 			pageSize: PAGE_SIZE,
-			order: config.order as ValidatorListOrder,
+			order: retainmentEnabled
+				? (config.order as ValidatorListOrder)
+				: 'ACTIVITY',
 			orderWindow: 'THREE_MONTHS',
 			retainmentWindows: ['ONE_MONTH', 'THREE_MONTHS'],
 			filters: {
@@ -74,7 +78,7 @@ export const StakingApiValidatorListInner = ({
 				search: config.search || undefined,
 			},
 		}),
-		[network, page, config],
+		[network, page, config, retainmentEnabled],
 	)
 	const { data, loading, error, refetch } = useValidatorList(variables)
 	const result = data.validatorList
@@ -164,7 +168,16 @@ export const StakingApiValidatorListInner = ({
 	return (
 		<ListWrapper>
 			<List $flexBasisLarge="50%" $twoColumnMinWidth={1350}>
-				<Controls config={config} disabled={loading} onApply={applyConfig} />
+				<Controls
+					config={config}
+					disabled={loading}
+					onApply={applyConfig}
+					orderOptions={
+						retainmentEnabled
+							? undefined
+							: [{ key: 'ACTIVITY', label: t('activity') }]
+					}
+				/>
 				<FilterHeaderWrapper>
 					<div>
 						<ResultSummary>
@@ -246,6 +259,11 @@ export const StakingApiValidatorList = (
 	props: StakingApiValidatorListProps,
 ) => (
 	<ListProvider initialListFormat="row">
-		<StakingApiValidatorListInner {...props} />
+		<NetworkValidatorList {...props} />
 	</ListProvider>
 )
+
+const NetworkValidatorList = (props: StakingApiValidatorListProps) => {
+	const { network } = useNetwork()
+	return <StakingApiValidatorListInner key={network} {...props} />
+}

--- a/packages/app-staking/src/library/Sync/index.tsx
+++ b/packages/app-staking/src/library/Sync/index.tsx
@@ -3,7 +3,6 @@
 
 import { pageFromUri } from '@w3ux/utils'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
-import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useNominationWarnings } from 'hooks/useNominationWarnings'
 import { useSyncing } from 'hooks/useSyncing'
 import { useTxMeta } from 'hooks/useTxMeta'
@@ -15,7 +14,6 @@ export const Sync = () => {
 	const { syncing } = useSyncing()
 	const { pathname } = useLocation()
 	const { bondedPools } = useBondedPools()
-	const { getValidators } = useValidators()
 	const { isLoading: warningsLoading } = useNominationWarnings()
 
 	// Keep syncing if on pools page and still fetching bonded pools or pool members
@@ -28,22 +26,10 @@ export const Sync = () => {
 		return false
 	}
 
-	// Keep syncing if on validators page and still fetching
-	const onValidatorsSyncing = () => {
-		if (
-			pageFromUri(pathname, 'overview') === 'validators' &&
-			!getValidators().length
-		) {
-			return true
-		}
-		return false
-	}
-
 	const isSyncing =
 		syncing ||
 		warningsLoading ||
 		onPoolsSyncing() ||
-		onValidatorsSyncing() ||
 		uids.filter(({ submitted }) => submitted).length > 0
 
 	return isSyncing ? (

--- a/packages/app-staking/src/library/ValidatorList/BasicItem.tsx
+++ b/packages/app-staking/src/library/ValidatorList/BasicItem.tsx
@@ -31,8 +31,11 @@ const Basic = ({
 	rate,
 }: ItemProps) => {
 	const { selectable, selected } = useList()
-	const { validatorIdentities, validatorSupers } = useValidators()
-	const { address, prefs, validatorStatus } = validator
+	const { validatorIdentities, validatorSupers, getValidatorPrefs } =
+		useValidators([validator.address])
+	const { address, validatorStatus } = validator
+	const resolvedPrefs = getValidatorPrefs(address)
+	const prefs = resolvedPrefs === undefined ? validator.prefs : resolvedPrefs
 
 	const isSelected = !!selected.filter(
 		(item) => (item as Validator).address === validator.address,

--- a/packages/app-staking/src/library/ValidatorList/DetailedItem.tsx
+++ b/packages/app-staking/src/library/ValidatorList/DetailedItem.tsx
@@ -52,8 +52,11 @@ export const DetailedItem = ({
 	const { network } = useNetwork()
 	const retainmentEnabled = useRetainmentStatsEnabled()
 	const { selectable, selected } = useList()
-	const { validatorIdentities, validatorSupers } = useValidators()
-	const { address, prefs, validatorStatus } = validator
+	const { validatorIdentities, validatorSupers, getValidatorPrefs } =
+		useValidators([validator.address])
+	const { address, validatorStatus } = validator
+	const resolvedPrefs = getValidatorPrefs(address)
+	const prefs = resolvedPrefs === undefined ? validator.prefs : resolvedPrefs
 	const { unit, units } = getStakingChainData(network)
 	const { selfStake, selfStakeMax } = useValidatorSelfStake(address, units)
 	const {
@@ -179,7 +182,7 @@ export const DetailedItem = ({
 				selfStakeMax={selfStakeMax}
 				selected={isSelected}
 				unit={unit}
-				validator={validator}
+				validator={{ ...validator, prefs }}
 				warnings={warningBadges}
 			/>
 		)

--- a/packages/app-staking/src/library/ValidatorList/index.tsx
+++ b/packages/app-staking/src/library/ValidatorList/index.tsx
@@ -60,7 +60,10 @@ export const ValidatorListInner = ({
 	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 	const { erasPerDay } = useErasPerDay()
 	const { setModalResize } = useOverlay().modal
-	const { injectValidatorListData } = useValidators()
+	// Filters need records for the full input, even when every visible row is removed.
+	const { injectValidatorListData } = useValidators(
+		initialValidators.map(({ address }) => address),
+	)
 	const { isReady, activeEra } = useApi()
 	const { applyConfig } = useValidatorFilters()
 	const {

--- a/packages/app-staking/src/modals/Invite/index.tsx
+++ b/packages/app-staking/src/modals/Invite/index.tsx
@@ -5,7 +5,6 @@ import { faEnvelopeOpenText, faList } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useActiveAccount } from '@polkadot-cloud/connect'
 import { StakingProductionURL } from 'consts'
-import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { useBalances } from 'hooks/useBalances'
 import { useNetwork } from 'hooks/useNetwork'
 import { useTranslation } from 'react-i18next'
@@ -16,11 +15,12 @@ import { Padding, Support } from 'ui-core/modal'
 export const Invite = () => {
 	const { network } = useNetwork()
 	const { t } = useTranslation()
-	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { getPoolMembership, getNominations } = useBalances()
 
-	const nominated = formatWithPrefs(getNominations(activeAddress))
+	const nominated = getNominations(activeAddress).map((address) => ({
+		address,
+	}))
 	const { membership } = getPoolMembership(activeAddress)
 	const poolId = membership?.poolId || 0
 

--- a/packages/app-staking/src/pages/Nominate/Active/index.tsx
+++ b/packages/app-staking/src/pages/Nominate/Active/index.tsx
@@ -23,11 +23,11 @@ export const Active = () => {
 	const { syncing } = useSyncing()
 	const { isBonding } = useStaking()
 	const { getNominations } = useBalances()
-	const { formatWithPrefs } = useValidators()
 	const { activeAddress } = useActiveAccount()
 	const { activeNominators, minimumNominatorBond, minimumActiveStake } =
 		useNominatorStats()
 
+	const { formatWithPrefs } = useValidators(getNominations(activeAddress))
 	const nominated = formatWithPrefs(getNominations(activeAddress))
 	const ROW_HEIGHT = 220
 

--- a/packages/app-staking/src/pages/Nominate/Standalone.tsx
+++ b/packages/app-staking/src/pages/Nominate/Standalone.tsx
@@ -22,12 +22,16 @@ export const NominateStandalone = () => {
 	const { getNominations } = useBalances()
 	const { activeAddress } = useActiveAccount()
 	const { isBonding, isNominator } = useStaking()
-	const { formatWithPrefs } = useValidatorEntries()
 	const { isLoading, isValidator } = useValidators()
 	const { accountsInitialised } = useImportedAccounts()
 	const { activePool, activePoolNominations, isOwner } = useActivePool()
 
 	const isPool = Boolean(activePool) && isOwner()
+	const { formatWithPrefs } = useValidatorEntries(
+		isPool
+			? (activePoolNominations?.targets ?? [])
+			: getNominations(activeAddress),
+	)
 	const nominated = formatWithPrefs(
 		isPool
 			? (activePoolNominations?.targets ?? [])

--- a/packages/app-staking/src/pages/Pools/ManagePool/index.tsx
+++ b/packages/app-staking/src/pages/Pools/ManagePool/index.tsx
@@ -9,10 +9,12 @@ import { CardWrapper } from 'ui-app/Card'
 import { Page } from 'ui-core/base'
 
 export const ManagePool = () => {
-	const { formatWithPrefs } = useValidators()
 	const { isOwner, isNominator, activePoolNominations, activePool } =
 		useActivePool()
 
+	const { formatWithPrefs } = useValidators(
+		activePoolNominations?.targets ?? [],
+	)
 	const poolNominated = activePoolNominations
 		? formatWithPrefs(activePoolNominations.targets)
 		: []

--- a/packages/app-staking/src/pages/Rewards/PayoutList/Inner.tsx
+++ b/packages/app-staking/src/pages/Rewards/PayoutList/Inner.tsx
@@ -3,12 +3,10 @@
 
 import { faBars, faGripVertical } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { ellipsisFn } from '@w3ux/utils'
 import BigNumber from 'bignumber.js'
 import { getStakingChainData } from 'consts/util'
 import { ListProvider, useList } from 'contexts/List'
 import { useBondedPools } from 'contexts/Pools/BondedPools'
-import { useValidators } from 'contexts/Validators/ValidatorEntries'
 import { formatDistance, fromUnixTime } from 'date-fns'
 import { useApi } from 'hooks/useApi'
 import { useDateFormat } from 'hooks/useDateFormat'
@@ -47,7 +45,6 @@ export const PayoutList = ({
 	const { isReady, activeEra } = useApi()
 	const { network } = useNetwork()
 	const { bondedPools } = useBondedPools()
-	const { getValidators } = useValidators()
 	const { getThemeValue } = useThemeValues()
 	const dateFormat = useDateFormat(i18n.resolvedLanguage)
 	const {
@@ -96,8 +93,6 @@ export const PayoutList = ({
 			? `${t('syncing', { ns: 'app' })}...`
 			: `${t('noRecentPayouts')}.`
 		: null
-
-	const allValidators = getValidators()
 
 	return (
 		<ListWrapper>
@@ -158,7 +153,6 @@ export const PayoutList = ({
 									? 'claim'
 									: 'reward'
 
-							let batchIndex
 							let pool: BondedPool | undefined
 							let keyId: string
 							if (poolReward) {
@@ -167,14 +161,9 @@ export const PayoutList = ({
 									({ id }) => id === item.poolId,
 								)
 								pool = poolIndex >= 0 ? bondedPools[poolIndex] : undefined
-								batchIndex = Math.max(poolIndex, 0)
 								keyId = `pool_${item.source ?? 'claim'}_${item.poolId}_${item.timestamp}`
 							} else {
 								const item = p as NominatorReward
-								const validatorIndex = allValidators.findIndex(
-									(v) => v.address === item.validator,
-								)
-								batchIndex = Math.max(validatorIndex, 0)
 								keyId = `nom_${item.validator}_${item.era}_${item.timestamp}`
 							}
 
@@ -218,8 +207,7 @@ export const PayoutList = ({
 												<div>
 													<div>
 														{!poolReward ? (
-															<NominatorIdentity
-																batchIndex={batchIndex}
+															<Identity
 																address={(record as NominatorReward).validator}
 															/>
 														) : (
@@ -284,19 +272,6 @@ const EndBadge = ({ children }: { children: string }) => (
 		</ListEndBadge>
 	</motion.div>
 )
-
-export const NominatorIdentity = ({
-	batchIndex,
-	address,
-}: {
-	batchIndex: number
-	address: string
-}) =>
-	batchIndex > 0 ? (
-		<Identity address={address} />
-	) : (
-		<div>{ellipsisFn(address)}</div>
-	)
 
 export const PoolClaim = ({
 	pool,

--- a/packages/app-staking/src/pages/Validators/Content.tsx
+++ b/packages/app-staking/src/pages/Validators/Content.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useRetainmentStatsEnabled } from 'hooks/useRetainmentStatsEnabled'
+import { useValidatorDetailsEnabled } from 'hooks/useValidatorDetailsEnabled'
 import { lazy, Suspense } from 'react'
 import { PagePreloader } from 'ui-app/PagePreloader'
 
@@ -21,11 +21,11 @@ export const ValidatorsContent = ({
 	showShareLink?: boolean
 	toggleFavorites: boolean
 }) => {
-	const retainmentStatsEnabled = useRetainmentStatsEnabled()
+	const validatorDetailsEnabled = useValidatorDetailsEnabled()
 
 	return (
 		<Suspense fallback={<PagePreloader showStats />}>
-			{retainmentStatsEnabled ? (
+			{validatorDetailsEnabled ? (
 				<ValidatorsAPI
 					showShareLink={showShareLink}
 					toggleFavorites={toggleFavorites}

--- a/packages/app-staking/src/pages/Validators/ValidatorsNode.tsx
+++ b/packages/app-staking/src/pages/Validators/ValidatorsNode.tsx
@@ -10,6 +10,7 @@ import { ValidatorList } from 'library/ValidatorList'
 import { useTranslation } from 'react-i18next'
 import { CardWrapper } from 'ui-app/Card'
 import { Stat } from 'ui-app/Stat'
+import { ButtonSecondary } from 'ui-buttons'
 import { Page } from 'ui-core/base'
 
 export const ValidatorsNode = ({
@@ -22,7 +23,8 @@ export const ValidatorsNode = ({
 	const { t } = useTranslation('pages')
 	const { isReady } = useApi()
 	const validatorDetailsEnabled = useValidatorDetailsEnabled()
-	const { getValidators } = useValidators()
+	const { getValidators, validatorsFetched, validatorsError, retryValidators } =
+		useValidators([], true)
 	const validators = getValidators()
 	const { activeValidators, totalValidators, minValidatorBond } =
 		useValidatorStats()
@@ -33,18 +35,26 @@ export const ValidatorsNode = ({
 			</Stat.Row>
 			<Page.Row>
 				<CardWrapper>
-					{!isReady ? (
+					{validatorsError ? (
+						<div className="item">
+							<h3>{t('errorUnknown', { ns: 'app' })}</h3>
+							<ButtonSecondary
+								text={t('tryAgain', { ns: 'app' })}
+								onClick={retryValidators}
+							/>
+						</div>
+					) : !isReady ? (
 						<div className="item">
 							<h3>{t('connecting')}...</h3>
 						</div>
 					) : (
 						<>
-							{validators.length === 0 && (
+							{validatorsFetched !== 'synced' && (
 								<div className="item">
 									<h3>{t('fetchingValidators')}...</h3>
 								</div>
 							)}
-							{validators.length > 0 && (
+							{validatorsFetched === 'synced' && validators.length > 0 && (
 								<ValidatorList
 									validators={validators}
 									selectable={false}

--- a/packages/data-gate/src/index.ts
+++ b/packages/data-gate/src/index.ts
@@ -16,4 +16,6 @@ export type {
 	Subscribe,
 	SubscriptionContext,
 } from './types'
+export { useValidatorRecords } from './validatorEntries'
+export { useValidatorPrefs } from './validatorPrefs'
 export { useValidatorRewardRates } from './validatorRewardRates'

--- a/packages/data-gate/src/useDataPoint.ts
+++ b/packages/data-gate/src/useDataPoint.ts
@@ -7,11 +7,14 @@ import { dataPointOptions } from './query'
 import type { DataPointConfig } from './types'
 
 // Data-point modules declare their sources; data gate owns query execution and result state.
-export const useDataPoint = <T>(config: DataPointConfig<T>) => {
+export const useDataPoint = <T, Selected = T>(
+	config: DataPointConfig<T>,
+	select?: (data: T) => Selected,
+) => {
 	// Re-evaluate source selection when the provider's network or plugin snapshot changes.
 	useDataGate()
 	const options = dataPointOptions(config)
-	const { data, error, isPending, refetch } = useQuery(options)
+	const { data, error, isPending, refetch } = useQuery({ ...options, select })
 	return {
 		data: options.enabled ? data : undefined,
 		error,

--- a/packages/data-gate/src/validatorEntries/api.ts
+++ b/packages/data-gate/src/validatorEntries/api.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { fetchValidatorRecords } from 'plugin-staking-api'
+import {
+	formatIdentitiesFromCache,
+	formatSuperIdentitiesFromCache,
+} from 'utils'
+import type { DataPointSource } from '../types'
+import type { ValidatorRecords } from '.'
+
+// Both record and preference consumers observe this API query; select only changes their view.
+export const validatorRecordsKey = (
+	era: number,
+	targets: string[],
+	allNodeEntries = false,
+) => ['validator-records', era, targets, allNodeEntries]
+
+export const validatorRecordsApiSource = (
+	targets: string[],
+): DataPointSource<ValidatorRecords> => ({
+	enabled: targets.length > 0,
+	refreshInterval: 60_000,
+	queryFn: async ({ network, signal }) => {
+		const records = await fetchValidatorRecords(network, targets, signal)
+		const identities = records.flatMap(({ address, identity }) =>
+			identity ? [{ address, ...identity }] : [],
+		)
+		return {
+			prefs: Object.fromEntries(
+				records.map(({ address, prefs }) => [address, prefs]),
+			),
+			identities: formatIdentitiesFromCache(targets, identities),
+			supers: formatSuperIdentitiesFromCache(identities),
+		}
+	},
+})

--- a/packages/data-gate/src/validatorEntries/index.ts
+++ b/packages/data-gate/src/validatorEntries/index.ts
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { pluginEnabled } from 'global-bus'
-import { fetchValidatorRecords } from 'plugin-staking-api'
 import type { IdentityOf, SuperIdentity } from 'types'
-import {
-	formatIdentities,
-	formatIdentitiesFromCache,
-	formatSuperIdentities,
-	formatSuperIdentitiesFromCache,
-} from 'utils'
+import { formatIdentities, formatSuperIdentities } from 'utils'
 import { useDataGate } from '../provider'
 import { useDataPoint } from '../useDataPoint'
+import { validatorRecordsApiSource, validatorRecordsKey } from './api'
 import { useNodeValidatorEntries } from './node'
 
 export interface ValidatorRecords {
@@ -38,7 +33,7 @@ export const useValidatorRecords = (
 			? targets.filter((address) => !entriesByAddress.has(address))
 			: targets
 	const result = useDataPoint<ValidatorRecords>({
-		key: ['validator-records', era, requestedKey, !api && allNodeEntries],
+		key: validatorRecordsKey(era, requestedKey, !api && allNodeEntries),
 		node: {
 			enabled: enabled && ready && era > 0,
 			queryFn: async ({ signal }) => {
@@ -67,23 +62,7 @@ export const useValidatorRecords = (
 				}
 			},
 		},
-		stakingApi: {
-			enabled: targets.length > 0,
-			refreshInterval: 60_000,
-			queryFn: async ({ network, signal }) => {
-				const records = await fetchValidatorRecords(network, targets, signal)
-				const identities = records.flatMap(({ address, identity }) =>
-					identity ? [{ address, ...identity }] : [],
-				)
-				return {
-					prefs: Object.fromEntries(
-						records.map((record) => [record.address, record.prefs]),
-					),
-					identities: formatIdentitiesFromCache(targets, identities),
-					supers: formatSuperIdentitiesFromCache(identities),
-				}
-			},
-		},
+		stakingApi: validatorRecordsApiSource(targets),
 	})
 	return {
 		...result,

--- a/packages/data-gate/src/validatorEntries/index.ts
+++ b/packages/data-gate/src/validatorEntries/index.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { pluginEnabled } from 'global-bus'
+import { fetchValidatorRecords } from 'plugin-staking-api'
+import type { IdentityOf, SuperIdentity } from 'types'
+import {
+	formatIdentities,
+	formatIdentitiesFromCache,
+	formatSuperIdentities,
+	formatSuperIdentitiesFromCache,
+} from 'utils'
+import { useDataGate } from '../provider'
+import { useDataPoint } from '../useDataPoint'
+import { useNodeValidatorEntries } from './node'
+
+export interface ValidatorRecords {
+	prefs: Record<string, { commission: number; blocked: boolean } | null>
+	identities: Record<string, IdentityOf>
+	supers: Record<string, SuperIdentity>
+}
+
+// Node consumers share the raw scan. API consumers fetch only their requested addresses.
+export const useValidatorRecords = (
+	addresses: string[],
+	allNodeEntries = false,
+) => {
+	const { node, era, ready } = useDataGate()
+	const api = pluginEnabled('staking_api')
+	const targets = [...new Set(addresses)].sort()
+	const enabled = targets.length > 0 || (!api && allNodeEntries)
+	const snapshot = useNodeValidatorEntries(enabled && !api)
+	// A full node snapshot already includes its list items. Mounting those items must not replace the
+	// query (and its loading state) with another identical full-list request.
+	const entriesByAddress = new Set(snapshot.data?.map(({ address }) => address))
+	const requestedKey =
+		!api && allNodeEntries
+			? targets.filter((address) => !entriesByAddress.has(address))
+			: targets
+	const result = useDataPoint<ValidatorRecords>({
+		key: ['validator-records', era, requestedKey, !api && allNodeEntries],
+		node: {
+			enabled: enabled && ready && era > 0,
+			queryFn: async ({ signal }) => {
+				const entries = await snapshot.fetchEntries()
+				signal.throwIfAborted()
+				const requested = allNodeEntries
+					? [...new Set([...targets, ...entries.map(({ address }) => address)])]
+					: targets
+				const [identities, supers] = await Promise.all([
+					node.query.identityOfMulti(requested),
+					node.query.superOfMulti(requested),
+				])
+				signal.throwIfAborted()
+				const byAddress = new Map(
+					entries.map((entry) => [entry.address, entry.prefs]),
+				)
+				return {
+					prefs: Object.fromEntries(
+						requested.map((address) => [
+							address,
+							byAddress.get(address) ?? null,
+						]),
+					),
+					identities: formatIdentities(requested, identities),
+					supers: formatSuperIdentities(supers),
+				}
+			},
+		},
+		stakingApi: {
+			enabled: targets.length > 0,
+			refreshInterval: 60_000,
+			queryFn: async ({ network, signal }) => {
+				const records = await fetchValidatorRecords(network, targets, signal)
+				const identities = records.flatMap(({ address, identity }) =>
+					identity ? [{ address, ...identity }] : [],
+				)
+				return {
+					prefs: Object.fromEntries(
+						records.map((record) => [record.address, record.prefs]),
+					),
+					identities: formatIdentitiesFromCache(targets, identities),
+					supers: formatSuperIdentitiesFromCache(identities),
+				}
+			},
+		},
+	})
+	return {
+		...result,
+		loading: enabled && result.loading,
+		entries: !api ? snapshot.data : undefined,
+	}
+}

--- a/packages/data-gate/src/validatorEntries/node.ts
+++ b/packages/data-gate/src/validatorEntries/node.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import {
+	queryOptions,
+	skipToken,
+	useQuery,
+	useQueryClient,
+} from '@tanstack/react-query'
+import { PerbillMultiplier } from 'consts'
+import { getNetwork, pluginEnabled } from 'global-bus'
+import type { NetworkId, ServiceInterface, Validator } from 'types'
+import { useDataGate } from '../provider'
+
+export const nodeValidatorEntriesOptions = (
+	node: ServiceInterface,
+	network: NetworkId,
+	era: number,
+	enabled: boolean,
+) =>
+	queryOptions({
+		queryKey: ['validator-entries', network, 'node', era],
+		queryFn:
+			enabled && !pluginEnabled('staking_api')
+				? async ({ signal }): Promise<Validator[]> => {
+						signal.throwIfAborted()
+						// Guard imperative fetches as well as mounted consumers when the source changes.
+						if (pluginEnabled('staking_api'))
+							throw new Error('Node validator entries are disabled in API mode')
+						const entries = await node.query.validatorEntries()
+						signal.throwIfAborted()
+						return entries.map(([address, prefs]) => ({
+							address,
+							prefs: {
+								commission: Number(
+									(prefs.commission / PerbillMultiplier).toFixed(2),
+								),
+								blocked: prefs.blocked,
+							},
+						}))
+					}
+				: skipToken,
+		staleTime: Infinity,
+		gcTime: Infinity,
+		retry: false,
+	})
+
+export const useNodeValidatorEntries = (enabled = false) => {
+	const { node, era, ready } = useDataGate()
+	const client = useQueryClient()
+	const allowed = enabled && ready && era > 0 && !pluginEnabled('staking_api')
+	const options = nodeValidatorEntriesOptions(node, getNetwork(), era, allowed)
+	const query = useQuery(options)
+	return {
+		...query,
+		data: allowed ? query.data : undefined,
+		fetchEntries: () => client.fetchQuery(options),
+	}
+}

--- a/packages/data-gate/src/validatorPrefs/index.ts
+++ b/packages/data-gate/src/validatorPrefs/index.ts
@@ -1,53 +1,57 @@
 // Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { fetchValidatorRecords } from 'plugin-staking-api'
-import type { ValidatorPrefs } from 'types'
+import { pluginEnabled } from 'global-bus'
 import { perbillToPercent } from 'utils'
 import { useDataGate } from '../provider'
 import { useDataPoint } from '../useDataPoint'
+import type { ValidatorRecords } from '../validatorEntries'
+import {
+	validatorRecordsApiSource,
+	validatorRecordsKey,
+} from '../validatorEntries/api'
+
+const selectPrefs = ({ prefs }: Pick<ValidatorRecords, 'prefs'>) => prefs
 
 // Fetch preferences for a known set of addresses without loading validator entries.
 export const useValidatorPrefs = (addresses: string[]) => {
 	const { node, ready, era } = useDataGate()
 	const targets = [...new Set(addresses)].sort()
 	const enabled = targets.length > 0
-	const result = useDataPoint<Record<string, ValidatorPrefs | null>>({
-		key: ['validator-prefs', era, targets],
-		node: {
-			enabled: enabled && ready,
-			queryFn: async ({ signal }) => {
-				signal.throwIfAborted()
-				const prefs = await node.query.validatorsMulti(targets)
-				signal.throwIfAborted()
-				return Object.fromEntries(
-					targets.map((address, index) => {
-						const pref = prefs[index]
-						return [
-							address,
-							pref
-								? {
-										commission: Number(
-											perbillToPercent(pref.commission).toString(),
-										),
-										blocked: pref.blocked,
-									}
-								: null,
-						]
-					}),
-				)
+	const result = useDataPoint(
+		{
+			key: pluginEnabled('staking_api')
+				? validatorRecordsKey(era, targets)
+				: ['validator-prefs', era, targets],
+			node: {
+				enabled: enabled && ready,
+				queryFn: async ({ signal }) => {
+					signal.throwIfAborted()
+					const prefs = await node.query.validatorsMulti(targets)
+					signal.throwIfAborted()
+					return {
+						prefs: Object.fromEntries(
+							targets.map((address, index) => {
+								const pref = prefs[index]
+								return [
+									address,
+									pref
+										? {
+												commission: Number(
+													perbillToPercent(pref.commission).toString(),
+												),
+												blocked: pref.blocked,
+											}
+										: null,
+								]
+							}),
+						),
+					}
+				},
 			},
+			stakingApi: validatorRecordsApiSource(targets),
 		},
-		stakingApi: {
-			enabled,
-			refreshInterval: 60_000,
-			queryFn: async ({ network, signal }) => {
-				const records = await fetchValidatorRecords(network, targets, signal)
-				return Object.fromEntries(
-					records.map(({ address, prefs }) => [address, prefs]),
-				)
-			},
-		},
-	})
+		selectPrefs,
+	)
 	return { ...result, loading: enabled && result.loading }
 }

--- a/packages/data-gate/src/validatorPrefs/index.ts
+++ b/packages/data-gate/src/validatorPrefs/index.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { fetchValidatorRecords } from 'plugin-staking-api'
+import type { ValidatorPrefs } from 'types'
+import { perbillToPercent } from 'utils'
+import { useDataGate } from '../provider'
+import { useDataPoint } from '../useDataPoint'
+
+// Fetch preferences for a known set of addresses without loading validator entries.
+export const useValidatorPrefs = (addresses: string[]) => {
+	const { node, ready, era } = useDataGate()
+	const targets = [...new Set(addresses)].sort()
+	const enabled = targets.length > 0
+	const result = useDataPoint<Record<string, ValidatorPrefs | null>>({
+		key: ['validator-prefs', era, targets],
+		node: {
+			enabled: enabled && ready,
+			queryFn: async ({ signal }) => {
+				signal.throwIfAborted()
+				const prefs = await node.query.validatorsMulti(targets)
+				signal.throwIfAborted()
+				return Object.fromEntries(
+					targets.map((address, index) => {
+						const pref = prefs[index]
+						return [
+							address,
+							pref
+								? {
+										commission: Number(
+											perbillToPercent(pref.commission).toString(),
+										),
+										blocked: pref.blocked,
+									}
+								: null,
+						]
+					}),
+				)
+			},
+		},
+		stakingApi: {
+			enabled,
+			refreshInterval: 60_000,
+			queryFn: async ({ network, signal }) => {
+				const records = await fetchValidatorRecords(network, targets, signal)
+				return Object.fromEntries(
+					records.map(({ address, prefs }) => [address, prefs]),
+				)
+			},
+		},
+	})
+	return { ...result, loading: enabled && result.loading }
+}

--- a/packages/dedot-api/src/start.ts
+++ b/packages/dedot-api/src/start.ts
@@ -87,7 +87,10 @@ export const getDefaultService = async <T extends DefaultServiceNetworkId>(
 		[hubChainId]: 'connecting',
 	})
 
-	const apiHub = await DedotClient.new<Service[T][2]>(hubProvider)
+	const apiHub = await DedotClient.new<Service[T][2]>({
+		provider: hubProvider,
+		cacheMetadata: true,
+	})
 
 	setMultiApiStatus({
 		[network]: 'ready',

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,6 +18,7 @@
 		"@w3ux/utils": "^3.1.1",
 		"bignumber.js": "^11.1.5",
 		"consts": "workspace:*",
+		"data-gate": "workspace:*",
 		"date-fns": "^4.4.0",
 		"dedot": "^1.4.0",
 		"global-bus": "workspace:*",

--- a/packages/hooks/src/useFavoriteValidators/index.ts
+++ b/packages/hooks/src/useFavoriteValidators/index.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { getRelayChainData } from 'consts/util'
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useValidatorPrefs } from 'data-gate'
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
 import type { NetworkId, Validator } from 'types'
-import { perbillToPercent } from 'utils'
-import { useApi } from '../useApi'
 import { useNetwork } from '../useNetwork'
 import { createSingletonSignal } from '../util'
 import type { FavoriteValidatorsHookInterface } from './types'
@@ -14,12 +13,10 @@ export type { FavoriteValidatorsHookInterface } from './types'
 
 type FavoriteValidatorsStore = {
 	favorites: string[]
-	favoritesList: Validator[] | null
 }
 
 const favoriteValidatorsSignal = createSingletonSignal()
 const storesByNetwork: Partial<Record<NetworkId, FavoriteValidatorsStore>> = {}
-let currentFetchKey: string | null = null
 
 const getFavoriteValidatorsKey = (network: NetworkId) => `${network}_favorites`
 
@@ -58,7 +55,6 @@ const setLocalFavoriteValidators = (
 const getFavoriteValidatorsSnapshot = (network: NetworkId) => {
 	storesByNetwork[network] ??= {
 		favorites: getLocalFavoriteValidators(network),
-		favoritesList: null,
 	}
 	return storesByNetwork[network]
 }
@@ -68,21 +64,8 @@ const setFavoriteValidators = (network: NetworkId, favorites: string[]) => {
 	storesByNetwork[network] = {
 		...current,
 		favorites,
-		favoritesList: null,
 	}
 	setLocalFavoriteValidators(network, favorites)
-	favoriteValidatorsSignal.emit()
-}
-
-const setFavoriteValidatorsList = (
-	network: NetworkId,
-	favoritesList: Validator[],
-) => {
-	const current = getFavoriteValidatorsSnapshot(network)
-	storesByNetwork[network] = {
-		...current,
-		favoritesList,
-	}
 	favoriteValidatorsSignal.emit()
 }
 
@@ -92,60 +75,19 @@ const syncFavoriteValidators = (network: NetworkId) => {
 	if (JSON.stringify(current.favorites) !== JSON.stringify(localFavorites)) {
 		storesByNetwork[network] = {
 			favorites: localFavorites,
-			favoritesList: null,
 		}
 		favoriteValidatorsSignal.emit()
 	}
 }
 
-const fetchFavoriteValidatorsList = async (
-	network: NetworkId,
-	favorites: string[],
-	serviceApi: ReturnType<typeof useApi>['serviceApi'],
-) => {
-	const fetchKey = `${network}:${favorites.join(',')}`
-	currentFetchKey = fetchKey
-
-	if (!favorites.length) {
-		setFavoriteValidatorsList(network, [])
-		return
-	}
-
-	const resultsMulti = await serviceApi.query.validatorsMulti(favorites)
-	if (currentFetchKey !== fetchKey) {
-		return
-	}
-
-	setFavoriteValidatorsList(
-		network,
-		resultsMulti.flatMap((prefs, i) =>
-			prefs
-				? [
-						{
-							address: favorites[i],
-							prefs: {
-								commission: Number(
-									perbillToPercent(prefs.commission).toString(),
-								),
-								blocked: prefs.blocked,
-							},
-						},
-					]
-				: [],
-		),
-	)
-}
-
 const serverFavoriteValidatorsSnapshot: FavoriteValidatorsStore = {
 	favorites: [],
-	favoritesList: null,
 }
 
 export const useFavoriteValidators = (): FavoriteValidatorsHookInterface => {
-	const { isReady, serviceApi } = useApi()
 	const { network } = useNetwork()
 	const { name } = getRelayChainData(network)
-	const { favorites, favoritesList } = useSyncExternalStore(
+	const { favorites } = useSyncExternalStore(
 		favoriteValidatorsSignal.subscribe,
 		() => getFavoriteValidatorsSnapshot(name),
 		() => serverFavoriteValidatorsSnapshot,
@@ -155,11 +97,15 @@ export const useFavoriteValidators = (): FavoriteValidatorsHookInterface => {
 		syncFavoriteValidators(name)
 	}, [name])
 
-	useEffect(() => {
-		if (isReady) {
-			void fetchFavoriteValidatorsList(name, favorites, serviceApi)
-		}
-	}, [isReady, name, favorites, serviceApi])
+	const { data: prefs } = useValidatorPrefs(favorites)
+	const favoritesList = useMemo<Validator[] | null>(() => {
+		if (!favorites.length) return []
+		if (!prefs) return null
+		return favorites.flatMap((address) => {
+			const pref = prefs[address]
+			return pref ? [{ address, prefs: pref }] : []
+		})
+	}, [favorites, prefs])
 
 	const addFavorite = useCallback(
 		(address: string) => {

--- a/packages/plugin-staking-api/src/index.ts
+++ b/packages/plugin-staking-api/src/index.ts
@@ -5,6 +5,7 @@ import { ApolloProvider } from '@apollo/client/react'
 
 export * from './Client'
 export * from './queries/activeValidatorRanks'
+export * from './queries/basicValidatorCandidates'
 export * from './queries/combinedPoolRewards'
 export * from './queries/eraActiveNominatorCount'
 export * from './queries/eraTotalNominators'
@@ -39,9 +40,9 @@ export * from './queries/validatorDetailsBatch'
 export * from './queries/validatorEraPoints'
 export * from './queries/validatorEraPointsBatch'
 export * from './queries/validatorList'
+export * from './queries/validatorRecords'
 export * from './queries/validatorRetainment'
 export * from './queries/validatorRewards'
 export * from './queries/validatorStats'
 export * from './util'
-
 export { ApolloProvider }

--- a/packages/plugin-staking-api/src/queries/basicValidatorCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/basicValidatorCandidates.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql } from '@apollo/client'
+import type { ValidatorCandidate } from '../types'
+import { fetchQuery } from './generic'
+
+const QUERY = gql`
+  query BasicValidatorCandidates($network: String!, $strategy: BasicValidatorStrategy!, $excludeAddresses: [String!]!) {
+    basicValidatorCandidates(network: $network, strategy: $strategy, excludeAddresses: $excludeAddresses) {
+      address
+      prefs { commission blocked }
+    }
+  }
+`
+
+export const fetchBasicValidatorCandidates = async (
+	network: string,
+	strategy: 'RANDOM' | 'ACTIVE' | 'HIGH_ACTIVITY' | 'OPTIMAL',
+	excludeAddresses: string[] = [],
+): Promise<ValidatorCandidate[]> => {
+	const result = await fetchQuery<{
+		basicValidatorCandidates: ValidatorCandidate[]
+	}>(
+		QUERY,
+		{ network, strategy, excludeAddresses },
+		{ basicValidatorCandidates: [] },
+		{ fetchPolicy: 'no-cache', throwOnError: true },
+	)
+	return result.basicValidatorCandidates
+}

--- a/packages/plugin-staking-api/src/queries/optimalValidatorBatch.ts
+++ b/packages/plugin-staking-api/src/queries/optimalValidatorBatch.ts
@@ -37,4 +37,5 @@ export const fetchOptimalValidatorBatch = (
 ) =>
 	fetchQuery<OptimalValidatorBatchData>(QUERY, variables, DEFAULT, {
 		fetchPolicy: 'no-cache',
+		throwOnError: true,
 	})

--- a/packages/plugin-staking-api/src/queries/sanitizeNomineeCandidates.ts
+++ b/packages/plugin-staking-api/src/queries/sanitizeNomineeCandidates.ts
@@ -31,4 +31,5 @@ export const fetchSanitizeNomineeCandidates = (
 		QUERY,
 		{ network, candidates },
 		{ sanitizeNomineeCandidates: candidates },
+		{ throwOnError: true, fetchPolicy: 'no-cache' },
 	)

--- a/packages/plugin-staking-api/src/queries/searchValidators.ts
+++ b/packages/plugin-staking-api/src/queries/searchValidators.ts
@@ -6,8 +6,8 @@ import type { SearchValidatorsData } from '../types'
 import { fetchQuery } from './generic'
 
 const QUERY = gql`
-  query SearchValidators($network: String!, $searchTerm: String!) {
-    searchValidators(network: $network, searchTerm: $searchTerm) {
+  query SearchValidators($network: String!, $searchTerm: String!, $maxCommission: Float, $limit: Int) {
+    searchValidators(network: $network, searchTerm: $searchTerm, maxCommission: $maxCommission, limit: $limit) {
       total
       validators {
         address
@@ -27,5 +27,26 @@ const DEFAULT: SearchValidatorsData = {
 	},
 }
 
-export const fetchSearchValidators = (network: string, searchTerm: string) =>
-	fetchQuery<SearchValidatorsData>(QUERY, { network, searchTerm }, DEFAULT)
+export const fetchSearchValidators = (
+	network: string,
+	searchTerm: string,
+	options?: { maxCommission?: number; limit?: number; signal?: AbortSignal },
+) =>
+	fetchQuery<SearchValidatorsData>(
+		QUERY,
+		{
+			network,
+			searchTerm,
+			maxCommission: options?.maxCommission,
+			limit: options?.limit,
+		},
+		DEFAULT,
+		{
+			throwOnError: true,
+			fetchPolicy: 'no-cache',
+			context: {
+				fetchOptions: { signal: options?.signal },
+				queryDeduplication: false,
+			},
+		},
+	)

--- a/packages/plugin-staking-api/src/queries/validatorCandidateBatch.ts
+++ b/packages/plugin-staking-api/src/queries/validatorCandidateBatch.ts
@@ -68,7 +68,7 @@ export const fetchValidatorCandidateBatch = async ({
 		getQuery(strategies.length),
 		{ ...variables, ...strategyVariables },
 		{},
-		{ fetchPolicy: 'no-cache' },
+		{ fetchPolicy: 'no-cache', throwOnError: true },
 	)
 
 	return strategies.map((strategy, index) => ({

--- a/packages/plugin-staking-api/src/queries/validatorRecords.ts
+++ b/packages/plugin-staking-api/src/queries/validatorRecords.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { gql } from '@apollo/client'
+import type { IdentityCache } from '../types'
+import { fetchQuery } from './generic'
+
+export interface ValidatorRecord {
+	address: string
+	registered: boolean
+	prefs: { commission: number; blocked: boolean } | null
+	identity: Omit<IdentityCache, 'address'> | null
+}
+
+const QUERY = gql`
+ query ValidatorRecords($network: String!, $addresses: [String!]!) {
+  validatorRecords(network: $network, addresses: $addresses) {
+   address registered prefs { commission blocked }
+   identity { display superDisplay superValue }
+  }
+ }
+`
+
+export const fetchValidatorRecords = async (
+	network: string,
+	addresses: string[],
+	signal: AbortSignal,
+) => {
+	const records: ValidatorRecord[] = []
+	for (let i = 0; i < addresses.length; i += 100) {
+		signal.throwIfAborted()
+		const batch = addresses.slice(i, i + 100)
+		const result = await fetchQuery<{ validatorRecords: ValidatorRecord[] }>(
+			QUERY,
+			{ network, addresses: batch },
+			{ validatorRecords: [] },
+			{
+				throwOnError: true,
+				fetchPolicy: 'no-cache',
+				context: { fetchOptions: { signal }, queryDeduplication: false },
+			},
+		)
+		signal.throwIfAborted()
+		if (
+			result.validatorRecords.length !== batch.length ||
+			result.validatorRecords.some((record, j) => record.address !== batch[j])
+		) {
+			throw new Error('Incomplete validator records response')
+		}
+		records.push(...result.validatorRecords)
+	}
+	return records
+}

--- a/packages/tests/src/dataGate.test.ts
+++ b/packages/tests/src/dataGate.test.ts
@@ -1039,7 +1039,9 @@ test.each([true, false])(
 				.data,
 		).toEqual(expected)
 		expect(
-			client.getQueryCache().findAll({ queryKey: ['validator-prefs'] }),
+			client.getQueryCache().findAll({
+				queryKey: [api ? 'validator-records' : 'validator-prefs'],
+			}),
 		).toHaveLength(1)
 		if (api) {
 			expect(apiQuery).toHaveBeenCalledTimes(1)
@@ -1066,7 +1068,7 @@ test('API preferences work before node readiness and errors never fetch node pre
 	apiQuery.mockRejectedValue(new Error('offline'))
 	const query = client
 		.getQueryCache()
-		.findAll({ queryKey: ['validator-prefs'] })[0]
+		.findAll({ queryKey: ['validator-records'] })[0]
 	await expect(query.fetch()).rejects.toThrow('offline')
 	expect(apiQuery).toHaveBeenCalledTimes(1)
 	expectNoNodeQueries(input.node)
@@ -1080,9 +1082,9 @@ test.each([true, false])(
 		const result = await renderValidatorPrefs(input, client, [])
 		expect(result.data).toBeUndefined()
 		expect(result.loading).toBe(false)
-		const query = client
-			.getQueryCache()
-			.findAll({ queryKey: ['validator-prefs'] })[0]
+		const query = client.getQueryCache().findAll({
+			queryKey: [api ? 'validator-records' : 'validator-prefs'],
+		})[0]
 		expect(query.options.queryFn).toBeTypeOf('symbol')
 		expectNoNodeQueries(input.node)
 		expect(apiQuery).not.toHaveBeenCalled()
@@ -1147,3 +1149,94 @@ test('late preference results stay isolated after changing network, source, or f
 	expect(input.node.query.validatorsMulti).toHaveBeenCalledTimes(1)
 	expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
 })
+
+test.each([true, false])(
+	'API records and preferences share requests, refreshes and errors (preferences first: %s)',
+	async (preferencesFirst) => {
+		const { useValidatorRecords } = await import(
+			'../../data-gate/src/validatorEntries'
+		)
+		const { useValidatorPrefs } = await import(
+			'../../data-gate/src/validatorPrefs'
+		)
+		const input = { ...config(true), ready: false, era: 0 }
+		const client = createClient()
+		let records!: ReturnType<typeof useValidatorRecords>
+		let prefs!: ReturnType<typeof useValidatorPrefs>
+		const Records = () => {
+			records = useValidatorRecords(['validator', 'missing'])
+			return null
+		}
+		const Prefs = () => {
+			prefs = useValidatorPrefs(['missing', 'validator', 'validator'])
+			return null
+		}
+		const render = () =>
+			renderToStaticMarkup(
+				createElement(
+					DataGateContext.Provider,
+					{ value: input },
+					createElement(
+						QueryClientProvider,
+						{ client },
+						createElement(preferencesFirst ? Prefs : Records),
+						createElement(preferencesFirst ? Records : Prefs),
+					),
+				),
+			)
+		const response = (commission: number, display: string) => ({
+			data: {
+				validatorRecords: [
+					{
+						address: 'missing',
+						registered: false,
+						prefs: null,
+						identity: null,
+					},
+					{
+						address: 'validator',
+						registered: true,
+						prefs: { commission, blocked: false },
+						identity: { display, superDisplay: null, superValue: null },
+					},
+				],
+			},
+		})
+		apiQuery.mockResolvedValue(response(3, 'Alice'))
+		render()
+		await Promise.all(
+			preferencesFirst
+				? [prefs.refetch(), records.refetch()]
+				: [records.refetch(), prefs.refetch()],
+		)
+		render()
+		expect(apiQuery).toHaveBeenCalledTimes(1)
+		expect(prefs.data).toEqual({
+			missing: null,
+			validator: { commission: 3, blocked: false },
+		})
+		expect(records.data?.prefs).toEqual(prefs.data)
+		expect(records.data?.identities.validator?.info.display.value).toBe('Alice')
+		expect(
+			client.getQueryCache().findAll({ queryKey: ['validator-records'] }),
+		).toHaveLength(1)
+		expect(
+			client.getQueryCache().findAll({ queryKey: ['validator-prefs'] }),
+		).toHaveLength(0)
+
+		apiQuery.mockResolvedValue(response(7, 'Bob'))
+		expect((await prefs.refetch()).data?.validator?.commission).toBe(7)
+		render()
+		expect(records.data?.identities.validator?.info.display.value).toBe('Bob')
+		expect(records.data?.prefs).toEqual(prefs.data)
+		expect(apiQuery).toHaveBeenCalledTimes(2)
+
+		apiQuery.mockRejectedValue(new Error('offline'))
+		expect((await records.refetch()).error?.message).toBe('offline')
+		render()
+		expect(prefs.error?.message).toBe('offline')
+		expect(prefs.data?.validator?.commission).toBe(7)
+		expect(records.data?.identities.validator?.info.display.value).toBe('Bob')
+		expectNoNodeQueries(input.node)
+	},
+)

--- a/packages/tests/src/dataGate.test.ts
+++ b/packages/tests/src/dataGate.test.ts
@@ -777,3 +777,194 @@ test.each(
 		expect(apiQuery).not.toHaveBeenCalled()
 	},
 )
+
+test('node validator entries are lazy and shared across consumers, with separate era and network caches', async () => {
+	const { nodeValidatorEntriesOptions } = await import(
+		'../../data-gate/src/validatorEntries/node'
+	)
+	const input = config()
+	input.node.query.validatorEntries.mockResolvedValue([
+		['validator', { commission: 25_000_000, blocked: false }],
+	])
+	const client = createClient()
+	const observer = new QueryObserver(
+		client,
+		nodeValidatorEntriesOptions(input.node, 'polkadot', 100, false),
+	)
+	observers.push(observer)
+	observer.subscribe(() => {})
+	expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
+	const options = nodeValidatorEntriesOptions(input.node, 'polkadot', 100, true)
+	const results = await Promise.all([
+		client.fetchQuery(options),
+		client.fetchQuery(options),
+	])
+	expect(results[0]).toEqual([
+		{ address: 'validator', prefs: { commission: 2.5, blocked: false } },
+	])
+	expect(results[1]).toEqual(results[0])
+	await client.fetchQuery(options)
+	expect(input.node.query.validatorEntries).toHaveBeenCalledTimes(1)
+	await client.fetchQuery(
+		nodeValidatorEntriesOptions(input.node, 'polkadot', 101, true),
+	)
+	await client.fetchQuery(
+		nodeValidatorEntriesOptions(input.node, 'kusama', 100, true),
+	)
+	expect(input.node.query.validatorEntries).toHaveBeenCalledTimes(3)
+})
+
+test.each(['polkadot', 'kusama'] as const)(
+	'API records on %s require no node readiness, handle missing validators, and never fall back to entries',
+	async (network) => {
+		const { useValidatorRecords } = await import(
+			'../../data-gate/src/validatorEntries'
+		)
+		const input = config(true)
+		setNetwork(network)
+		input.ready = false
+		input.era = 0
+		const client = createClient()
+		let result!: ReturnType<typeof useValidatorRecords>
+		const Consumer = () => {
+			result = useValidatorRecords(['missing', 'validator'])
+			return null
+		}
+		const render = () =>
+			renderToStaticMarkup(
+				createElement(
+					DataGateContext.Provider,
+					{ value: input },
+					createElement(
+						QueryClientProvider,
+						{ client },
+						createElement(Consumer),
+					),
+				),
+			)
+		render()
+		apiQuery.mockResolvedValue({
+			data: {
+				validatorRecords: [
+					{
+						address: 'missing',
+						registered: false,
+						prefs: null,
+						identity: null,
+					},
+					{
+						address: 'validator',
+						registered: true,
+						prefs: { commission: 3, blocked: false },
+						identity: {
+							display: 'Alice',
+							superDisplay: null,
+							superValue: null,
+						},
+					},
+				],
+			},
+		})
+		expect((await result.refetch()).data?.prefs).toEqual({
+			missing: null,
+			validator: { commission: 3, blocked: false },
+		})
+		expect(apiQuery.mock.lastCall?.[0].variables).toEqual({
+			network,
+			addresses: ['missing', 'validator'],
+		})
+		render()
+		expect(result.entries).toBeUndefined()
+		expect(result.data?.identities.validator?.info.display.value).toBe('Alice')
+		apiQuery.mockRejectedValue(new Error('offline'))
+		expect((await result.refetch()).error?.message).toBe('offline')
+		expectNoNodeQueries(input.node)
+	},
+)
+
+test('validator records with all-node demand still resolve explicitly requested unregistered addresses', async () => {
+	const { useValidatorRecords } = await import(
+		'../../data-gate/src/validatorEntries'
+	)
+	const input = config()
+	input.node.query.validatorEntries.mockResolvedValue([
+		['validator', { commission: 0, blocked: false }],
+	])
+	input.node.query.identityOfMulti.mockResolvedValue([])
+	input.node.query.superOfMulti.mockResolvedValue([])
+	const client = createClient()
+	let result!: ReturnType<typeof useValidatorRecords>
+	const Consumer = () => {
+		result = useValidatorRecords(['missing'], true)
+		return null
+	}
+	renderToStaticMarkup(
+		createElement(
+			DataGateContext.Provider,
+			{ value: input },
+			createElement(QueryClientProvider, { client }, createElement(Consumer)),
+		),
+	)
+	expect((await result.refetch()).data?.prefs).toEqual({
+		missing: null,
+		validator: { commission: 0, blocked: false },
+	})
+	expect(input.node.query.validatorEntries).toHaveBeenCalledTimes(1)
+})
+
+test('a captured entries query cannot start a scan after the API plugin is enabled', async () => {
+	const { nodeValidatorEntriesOptions } = await import(
+		'../../data-gate/src/validatorEntries/node'
+	)
+	const input = config()
+	const captured = nodeValidatorEntriesOptions(
+		input.node,
+		'polkadot',
+		100,
+		true,
+	)
+	setPlugins(['staking_api'])
+	await expect(createClient().fetchQuery(captured)).rejects.toThrow(
+		'disabled in API mode',
+	)
+	expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
+})
+
+test('mounting items from a loaded node list keeps the shared records query and loading state stable', async () => {
+	const { useValidatorRecords } = await import(
+		'../../data-gate/src/validatorEntries'
+	)
+	const input = config()
+	input.node.query.validatorEntries.mockResolvedValue([
+		['validator', { commission: 0, blocked: false }],
+	])
+	input.node.query.identityOfMulti.mockResolvedValue([])
+	input.node.query.superOfMulti.mockResolvedValue([])
+	const client = createClient()
+	let addresses: string[] = []
+	let result!: ReturnType<typeof useValidatorRecords>
+	const Consumer = () => {
+		result = useValidatorRecords(addresses, true)
+		return null
+	}
+	const render = () =>
+		renderToStaticMarkup(
+			createElement(
+				DataGateContext.Provider,
+				{ value: input },
+				createElement(QueryClientProvider, { client }, createElement(Consumer)),
+			),
+		)
+	render()
+	await result.refetch()
+	render()
+	expect(result.loading).toBe(false)
+	addresses = ['validator']
+	render()
+	expect(result.loading).toBe(false)
+	expect(
+		client.getQueryCache().findAll({ queryKey: ['validator-records'] }),
+	).toHaveLength(1)
+	expect(input.node.query.validatorEntries).toHaveBeenCalledTimes(1)
+	expect(input.node.query.identityOfMulti).toHaveBeenCalledTimes(1)
+})

--- a/packages/tests/src/dataGate.test.ts
+++ b/packages/tests/src/dataGate.test.ts
@@ -968,3 +968,182 @@ test('mounting items from a loaded node list keeps the shared records query and 
 	expect(input.node.query.validatorEntries).toHaveBeenCalledTimes(1)
 	expect(input.node.query.identityOfMulti).toHaveBeenCalledTimes(1)
 })
+
+const renderValidatorPrefs = async (
+	input: DataGateState,
+	client: QueryClient,
+	addresses: string[],
+) => {
+	const { useValidatorPrefs } = await import(
+		'../../data-gate/src/validatorPrefs'
+	)
+	let result!: ReturnType<typeof useValidatorPrefs>
+	const Consumer = () => {
+		result = useValidatorPrefs(addresses)
+		return null
+	}
+	renderToStaticMarkup(
+		createElement(
+			DataGateContext.Provider,
+			{ value: input },
+			createElement(QueryClientProvider, { client }, createElement(Consumer)),
+		),
+	)
+	return result
+}
+
+test.each([true, false])(
+	'validator preferences share concurrent requests for the same address set (API: %s)',
+	async (api) => {
+		const input = config(api)
+		const client = createClient()
+		input.node.query.validatorsMulti.mockResolvedValue([
+			undefined,
+			{ commission: 25_000_000, blocked: true },
+		])
+		apiQuery.mockResolvedValue({
+			data: {
+				validatorRecords: [
+					{
+						address: 'missing',
+						registered: false,
+						prefs: null,
+						identity: null,
+					},
+					{
+						address: 'validator',
+						registered: true,
+						prefs: { commission: 2.5, blocked: true },
+						identity: null,
+					},
+				],
+			},
+		})
+		const first = await renderValidatorPrefs(input, client, [
+			'validator',
+			'missing',
+		])
+		const second = await renderValidatorPrefs(input, client, [
+			'missing',
+			'validator',
+			'validator',
+		])
+		const results = await Promise.all([first.refetch(), second.refetch()])
+		const expected = {
+			missing: null,
+			validator: { commission: 2.5, blocked: true },
+		}
+		expect(results.map(({ data }) => data)).toEqual([expected, expected])
+		expect(
+			(await renderValidatorPrefs(input, client, ['validator', 'missing']))
+				.data,
+		).toEqual(expected)
+		expect(
+			client.getQueryCache().findAll({ queryKey: ['validator-prefs'] }),
+		).toHaveLength(1)
+		if (api) {
+			expect(apiQuery).toHaveBeenCalledTimes(1)
+			expect(apiQuery.mock.lastCall?.[0].variables.addresses).toEqual([
+				'missing',
+				'validator',
+			])
+			expectNoNodeQueries(input.node)
+		} else {
+			expect(input.node.query.validatorsMulti).toHaveBeenCalledExactlyOnceWith([
+				'missing',
+				'validator',
+			])
+			expect(apiQuery).not.toHaveBeenCalled()
+		}
+		expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
+	},
+)
+
+test('API preferences work before node readiness and errors never fetch node preferences', async () => {
+	const input = { ...config(true), ready: false, era: 0 }
+	const client = createClient()
+	await renderValidatorPrefs(input, client, ['validator'])
+	apiQuery.mockRejectedValue(new Error('offline'))
+	const query = client
+		.getQueryCache()
+		.findAll({ queryKey: ['validator-prefs'] })[0]
+	await expect(query.fetch()).rejects.toThrow('offline')
+	expect(apiQuery).toHaveBeenCalledTimes(1)
+	expectNoNodeQueries(input.node)
+})
+
+test.each([true, false])(
+	'empty favorites disable both preference sources (API: %s)',
+	async (api) => {
+		const input = config(api)
+		const client = createClient()
+		const result = await renderValidatorPrefs(input, client, [])
+		expect(result.data).toBeUndefined()
+		expect(result.loading).toBe(false)
+		const query = client
+			.getQueryCache()
+			.findAll({ queryKey: ['validator-prefs'] })[0]
+		expect(query.options.queryFn).toBeTypeOf('symbol')
+		expectNoNodeQueries(input.node)
+		expect(apiQuery).not.toHaveBeenCalled()
+	},
+)
+
+test('node preferences wait for readiness and then resolve without a full entries scan', async () => {
+	const input = { ...config(), ready: false }
+	const client = createClient()
+	expect(
+		(await renderValidatorPrefs(input, client, ['validator'])).loading,
+	).toBe(true)
+	expect(
+		client.getQueryCache().findAll({ queryKey: ['validator-prefs'] })[0].options
+			.queryFn,
+	).toBeTypeOf('symbol')
+	expectNoNodeQueries(input.node)
+	input.ready = true
+	input.node.query.validatorsMulti.mockResolvedValue([
+		{ commission: 0, blocked: false },
+	])
+	const result = await renderValidatorPrefs(input, client, ['validator'])
+	expect((await result.refetch()).data).toEqual({
+		validator: { commission: 0, blocked: false },
+	})
+	expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
+})
+
+test('late preference results stay isolated after changing network, source, or favorites', async () => {
+	const input = config()
+	const client = createClient()
+	const pending =
+		deferred<
+			Awaited<ReturnType<ServiceInterface['query']['validatorsMulti']>>
+		>()
+	input.node.query.validatorsMulti.mockReturnValue(pending.promise)
+	const old = await renderValidatorPrefs(input, client, ['old-validator'])
+	const oldRequest = old.refetch()
+	setNetwork('kusama')
+	setPlugins(['staking_api'])
+	apiQuery.mockResolvedValue({
+		data: {
+			validatorRecords: [
+				{
+					address: 'new-validator',
+					registered: true,
+					prefs: { commission: 5, blocked: false },
+					identity: null,
+				},
+			],
+		},
+	})
+	const current = await renderValidatorPrefs(input, client, ['new-validator'])
+	expect(current.data).toBeUndefined()
+	await current.refetch()
+	pending.resolve([{ commission: 0, blocked: true }])
+	await oldRequest
+	expect(
+		(await renderValidatorPrefs(input, client, ['new-validator'])).data,
+	).toEqual({ 'new-validator': { commission: 5, blocked: false } })
+	expect(apiQuery.mock.lastCall?.[0].variables.network).toBe('kusama')
+	expect(input.node.query.validatorsMulti).toHaveBeenCalledTimes(1)
+	expect(input.node.query.validatorEntries).not.toHaveBeenCalled()
+})

--- a/packages/tests/src/migrations.test.ts
+++ b/packages/tests/src/migrations.test.ts
@@ -74,6 +74,33 @@ describe('runMigrations', () => {
 		)
 	})
 
+	test('removes legacy validator caches without resetting preferences or completed migrations', () => {
+		const storage = createStorage({
+			migrationVersion: '1',
+			polkadot_validators: '{"era":"100","entries":[]}',
+			kusama_validators: 'invalid legacy data',
+			paseo_validators: '{"era":"200","entries":[]}',
+			polkadot_favorites: '["favorite-address"]',
+			autoRpc: 'true',
+			polkadotRpcEndpoints: '["wss://chosen.example"]',
+		})
+		vi.stubGlobal('localStorage', storage)
+
+		runMigrations()
+
+		expect(storage.getItem('polkadot_validators')).toBeNull()
+		expect(storage.getItem('kusama_validators')).toBeNull()
+		expect(storage.getItem('paseo_validators')).toBeNull()
+		expect(storage.getItem('polkadot_favorites')).toBe('["favorite-address"]')
+		expect(storage.getItem('autoRpc')).toBe('true')
+		expect(storage.getItem('polkadotRpcEndpoints')).toBe(
+			'["wss://chosen.example"]',
+		)
+		expect(storage.getItem('migrationVersion')).toBe(
+			String(GlobalMigrationVersion),
+		)
+	})
+
 	test('does not downgrade a newer global migration version', () => {
 		const newerVersion = GlobalMigrationVersion + 1
 		const storage = createStorage({

--- a/packages/tests/src/validatorCandidates.test.ts
+++ b/packages/tests/src/validatorCandidates.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { beforeEach, expect, test, vi } from 'vitest'
+import { useFetchMethods } from '../../app-staking/src/hooks/useFetchMethods'
+
+const { state, entries, basic, optimal, specialized, sanitize, demand } =
+	vi.hoisted(() => ({
+		state: { api: true, network: 'kusama' },
+		entries: vi.fn(),
+		basic: vi.fn(),
+		optimal: vi.fn(),
+		specialized: vi.fn(),
+		sanitize: vi.fn(),
+		demand: vi.fn(),
+	}))
+vi.mock('../../global-bus/src/index', () => ({
+	pluginEnabled: () => state.api,
+}))
+vi.mock('../../hooks/src/useNetwork', () => ({
+	useNetwork: () => ({ network: state.network }),
+}))
+vi.mock('../../hooks/src/useFavoriteValidators', () => ({
+	useFavoriteValidators: () => ({ favoritesList: [] }),
+}))
+vi.mock('contexts/Validators/ValidatorEntries', () => ({
+	useValidators: (...args: unknown[]) => {
+		demand(...args)
+		return { getValidators: entries, isValidatorHighPerformance: () => true }
+	},
+}))
+vi.mock('hooks/useValidatorFilters', () => ({
+	useValidatorFilters: () => ({
+		applyFilter: (_: unknown, __: unknown, candidates: unknown) => candidates,
+	}),
+}))
+vi.mock('../../plugin-staking-api/src/index', () => ({
+	fetchBasicValidatorCandidates: basic,
+	fetchOptimalValidatorBatch: optimal,
+	fetchValidatorCandidateBatch: specialized,
+	fetchSanitizeNomineeCandidates: sanitize,
+}))
+const candidate = { address: 'new', prefs: { commission: 3, blocked: false } }
+beforeEach(() => {
+	vi.clearAllMocks()
+	state.api = true
+	state.network = 'kusama'
+	basic.mockResolvedValue([candidate])
+	optimal.mockResolvedValue({ fetchOptimalValidatorBatch: [candidate] })
+	sanitize.mockResolvedValue({ sanitizeNomineeCandidates: [candidate] })
+	specialized.mockResolvedValue([{ candidate }])
+	entries.mockReturnValue([candidate])
+})
+
+test.each([
+	'Active Validator',
+	'Random Validator',
+	'High Performance Validator',
+] as const)(
+	'Kusama %s uses API candidates without local entries',
+	async (type) => {
+		const existing = [{ address: 'existing', prefs: null }]
+		expect(await useFetchMethods().add(existing, type)).toEqual([
+			...existing,
+			candidate,
+		])
+		expect(basic).toHaveBeenCalledWith(
+			'kusama',
+			type === 'Active Validator'
+				? 'ACTIVE'
+				: type === 'Random Validator'
+					? 'RANDOM'
+					: 'HIGH_ACTIVITY',
+			['existing'],
+		)
+		expect(entries).not.toHaveBeenCalled()
+		expect(demand).toHaveBeenCalledWith([], false)
+	},
+)
+
+test('Kusama optimal selection needs no retainment endpoint or local entries', async () => {
+	expect(await useFetchMethods().fetch('Optimal Selection')).toEqual([
+		candidate,
+	])
+	expect(basic).toHaveBeenCalledWith('kusama', 'OPTIMAL')
+	expect(optimal).not.toHaveBeenCalled()
+	expect(entries).not.toHaveBeenCalled()
+})
+
+test('Polkadot retains its existing optimal selection and sanitization', async () => {
+	state.network = 'polkadot'
+	expect(await useFetchMethods().fetch('Optimal Selection')).toEqual([
+		candidate,
+	])
+	expect(optimal).toHaveBeenCalledWith({ network: 'polkadot' })
+	expect(sanitize).toHaveBeenCalledWith('polkadot', [candidate])
+	expect(entries).not.toHaveBeenCalled()
+})
+
+test('API candidate errors cannot fall back to the local validator set', async () => {
+	basic.mockRejectedValue(new Error('offline'))
+	await expect(useFetchMethods().fetch('Optimal Selection')).rejects.toThrow(
+		'offline',
+	)
+	expect(entries).not.toHaveBeenCalled()
+})
+
+test('node mode requests the shared snapshot and uses its candidate set', async () => {
+	state.api = false
+	expect(await useFetchMethods().add([], 'Random Validator')).toEqual([
+		candidate,
+	])
+	expect(demand).toHaveBeenCalledWith([], true)
+	expect(entries).toHaveBeenCalled()
+	expect(basic).not.toHaveBeenCalled()
+})

--- a/packages/tests/src/validatorRecordsTransport.test.ts
+++ b/packages/tests/src/validatorRecordsTransport.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { afterAll, afterEach, expect, test, vi } from 'vitest'
+import { client } from '../../plugin-staking-api/src/Client'
+import { fetchValidatorRecords } from '../../plugin-staking-api/src/queries/validatorRecords'
+
+const { httpFetch } = vi.hoisted(() => {
+	const httpFetch = vi.fn<typeof fetch>()
+	vi.stubGlobal('fetch', httpFetch)
+	return { httpFetch }
+})
+afterEach(async () => {
+	await client.clearStore()
+	httpFetch.mockReset()
+})
+afterAll(() => {
+	client.stop()
+	vi.unstubAllGlobals()
+})
+
+test('targeted requests chunk large batches and preserve missing records without a full-list query', async () => {
+	const addresses = Array.from({ length: 205 }, (_, i) => `validator-${i}`)
+	httpFetch.mockImplementation(async (_, options) => {
+		const { query, variables } = JSON.parse(String(options?.body))
+		expect(query).not.toContain('validatorList(')
+		expect(variables.addresses.length).toBeLessThanOrEqual(100)
+		return Response.json({
+			data: {
+				validatorRecords: variables.addresses.map((address: string) => ({
+					address,
+					registered: false,
+					prefs: null,
+					identity: null,
+				})),
+			},
+		})
+	})
+	const result = await fetchValidatorRecords(
+		'kusama',
+		addresses,
+		new AbortController().signal,
+	)
+	expect(result.map(({ address }) => address)).toEqual(addresses)
+	expect(result.every(({ prefs }) => prefs === null)).toBe(true)
+	expect(httpFetch).toHaveBeenCalledTimes(3)
+})
+
+test.each(['missing', 'mismatch'])(
+	'incomplete or mismatched batches fail explicitly: %s',
+	async (kind) => {
+		httpFetch.mockResolvedValue(
+			Response.json({
+				data: {
+					validatorRecords:
+						kind === 'missing'
+							? []
+							: [
+									{
+										address: 'other',
+										registered: true,
+										prefs: { commission: 3, blocked: false },
+										identity: null,
+									},
+								],
+				},
+			}),
+		)
+		await expect(
+			fetchValidatorRecords(
+				'polkadot',
+				['validator'],
+				new AbortController().signal,
+			),
+		).rejects.toThrow()
+	},
+)
+
+test('an aborted batch never starts another chunk', async () => {
+	const controller = new AbortController()
+	httpFetch.mockImplementation(async (_, options) => {
+		const { variables } = JSON.parse(String(options?.body))
+		controller.abort()
+		return Response.json({
+			data: {
+				validatorRecords: variables.addresses.map((address: string) => ({
+					address,
+					registered: false,
+					prefs: null,
+					identity: null,
+				})),
+			},
+		})
+	})
+	await expect(
+		fetchValidatorRecords(
+			'kusama',
+			Array.from({ length: 101 }, (_, i) => `${i}`),
+			controller.signal,
+		),
+	).rejects.toThrow()
+	expect(httpFetch).toHaveBeenCalledTimes(1)
+})

--- a/packages/types/src/validators.ts
+++ b/packages/types/src/validators.ts
@@ -5,7 +5,7 @@ export type ValidatorStatus = 'waiting' | 'active'
 
 export interface Validator {
 	address: string
-	prefs: ValidatorPrefs
+	prefs: ValidatorPrefs | null
 }
 
 export interface ValidatorPrefs {

--- a/packages/utils/src/migrations.ts
+++ b/packages/utils/src/migrations.ts
@@ -4,7 +4,7 @@
 import { AutoRpcKey, rpcEndpointKey } from 'consts'
 import { NetworkList } from 'consts/networks'
 
-export const GlobalMigrationVersion = 1
+export const GlobalMigrationVersion = 2
 
 const GlobalMigrationVersionKey = 'migrationVersion'
 
@@ -18,8 +18,16 @@ const migrateRpcConfig = (): void => {
 	})
 }
 
+// Remove the obsolete persisted validator snapshots.
+const removeValidatorCache = (): void => {
+	Object.keys(NetworkList).forEach((network) => {
+		localStorage.removeItem(`${network}_validators`)
+	})
+}
+
 const migrations: Record<number, () => void> = {
 	1: migrateRpcConfig,
+	2: removeValidatorCache,
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -910,6 +910,9 @@ importers:
       consts:
         specifier: workspace:*
         version: link:../consts
+      data-gate:
+        specifier: workspace:*
+        version: link:../data-gate
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0


### PR DESCRIPTION
Validator entries currently live in the staking app’s provider and load a full node snapshot even when the Staking API is selected. This moves validator records and preferences into `data-gate`, with demand-based loading and queries scoped by network, source, era, and requested addresses.

- Add `useValidatorRecords` and `useValidatorPrefs`. Matching address sets share one API records query, with preferences selected from the cached result. API reads use batches of up to 100 and refresh every 60 seconds; node consumers share a lazy in-memory validator snapshot, while preference-only reads query the requested addresses directly. Missing validators retain `null` preferences, and API errors never trigger node fallback.
- Register demand from nomination lists, favorites, identities, and validator URLs. Lists retain their full input subscription while filtering, so removing every visible row does not discard the records needed by the filter. Remove the global validator-list sync dependency and add an error/retry state to the node validator page.
- Move API search and nomination candidate selection off the local validator set, including basic strategies for Kusama. Cancel stale search results, guard late nomination results, and surface candidate request failures.
- Use the API validator list on Kusama while keeping retainment controls limited to supported networks.
- Remove persisted era-validator snapshots and migrate away existing cache entries without clearing favorites or RPC preferences. Enable Dedot metadata caching for Asset Hub connections.

Validation: `pnpm test` passed (297 Vitest tests and 10 Dedot tests), including shared records/preferences requests, refreshes, and error propagation in either consumer order. `pnpm check`, license headers, locale validation, and `build:verify` for staking, nominate, validators, and swap passed. A mounted React check of the validator list confirmed that filtering out all Favorites settles without a render loop. Small read-only production API queries confirmed the validator-record, basic-candidate, and search fields.