### PR TITLE
feat: Support cloud rpc auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 # Polkadot Cloud Apps
 
+## Local RPC authentication
+
+Add `CLOUD_RPC_AUTH_TOKEN=your_dev_bearer_token` to the repository root `.env` file,
+then start or restart any app with its `pnpm dev:*` command. Store the token without
+the `Bearer` prefix.
+
+The shared Vite development proxy forwards the Polkadot Cloud Statemint and People
+connections with `Authorization: Bearer <token>`. This is needed because browsers
+cannot set WebSocket headers, including through Dedot's `headers` option. The token
+stays on the development server and is not included in client code. Other RPC
+providers connect directly. Without a token, Cloud endpoints are omitted from the
+available RPC providers and defaults in development.
+
+Production builds connect directly to the Cloud endpoints using the existing origin
+access rules; the development proxy and token are not needed for deployment.
+
 ## Staking Dashboard
 
 - [**English:** Welcome to Polkadot Cloud Staking!](https://docs.staking.polkadot.cloud/en/developer-overview)

--- a/packages/app-nominate/vite.config.ts
+++ b/packages/app-nominate/vite.config.ts
@@ -6,10 +6,15 @@ import { SimpleAnalyticsStakingHostname } from 'consts'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
+import {
+	cloudRpcPlugin,
+	sharedFaviconPlugins,
+	simpleAnalyticsPlugin,
+} from 'vite-shared'
 
 export default defineConfig({
 	plugins: [
+		cloudRpcPlugin(),
 		...sharedFaviconPlugins(),
 		simpleAnalyticsPlugin({ hostname: SimpleAnalyticsStakingHostname }),
 		react(),

--- a/packages/app-staking/vite.config.ts
+++ b/packages/app-staking/vite.config.ts
@@ -6,12 +6,17 @@ import { SimpleAnalyticsStakingHostname } from 'consts'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
+import {
+	cloudRpcPlugin,
+	sharedFaviconPlugins,
+	simpleAnalyticsPlugin,
+} from 'vite-shared'
 
 // https://vitejs.dev/config/
 // - `BASE_URL`env variable is used in the codebase to refer to the supplied base.
 export default defineConfig({
 	plugins: [
+		cloudRpcPlugin(),
 		...sharedFaviconPlugins(),
 		simpleAnalyticsPlugin({ hostname: SimpleAnalyticsStakingHostname }),
 		react(),

--- a/packages/app-swap/vite.config.ts
+++ b/packages/app-swap/vite.config.ts
@@ -5,10 +5,15 @@ import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
+import {
+	cloudRpcPlugin,
+	sharedFaviconPlugins,
+	simpleAnalyticsPlugin,
+} from 'vite-shared'
 
 export default defineConfig({
 	plugins: [
+		cloudRpcPlugin(),
 		...sharedFaviconPlugins(),
 		simpleAnalyticsPlugin(),
 		react(),

--- a/packages/app-validators/vite.config.ts
+++ b/packages/app-validators/vite.config.ts
@@ -6,10 +6,15 @@ import { SimpleAnalyticsStakingHostname } from 'consts'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
 import svgr from 'vite-plugin-svgr'
-import { sharedFaviconPlugins, simpleAnalyticsPlugin } from 'vite-shared'
+import {
+	cloudRpcPlugin,
+	sharedFaviconPlugins,
+	simpleAnalyticsPlugin,
+} from 'vite-shared'
 
 export default defineConfig({
 	plugins: [
+		cloudRpcPlugin(),
 		...sharedFaviconPlugins(),
 		simpleAnalyticsPlugin({ hostname: SimpleAnalyticsStakingHostname }),
 		react(),

--- a/packages/consts/src/index.ts
+++ b/packages/consts/src/index.ts
@@ -30,6 +30,7 @@ export const ManualSigners = ['ledger', 'vault']
 
 // RPC
 export const PolkadotCloudRpcStatemintUrl = 'wss://rpc.polkadot.cloud/statemint'
+export const PolkadotCloudRpcPeopleUrl = 'wss://rpc.polkadot.cloud/people'
 
 // Element Thresholds
 export const SideMenuHiddenWidth = 250

--- a/packages/consts/src/rpc.ts
+++ b/packages/consts/src/rpc.ts
@@ -2,15 +2,31 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainId, RpcEndpoints } from 'types'
-import { PolkadotCloudRpcStatemintUrl } from '.'
+import { PolkadotCloudRpcPeopleUrl, PolkadotCloudRpcStatemintUrl } from '.'
 
 export type RpcChainId = ChainId | 'hydration'
 
-const isProduction =
-	(import.meta as ImportMeta & { env?: { PROD?: boolean } }).env?.PROD === true
+const proxyPath = import.meta.env?.CLOUD_RPC_PROXY_PATH
+// Production uses origin access; development requires the authenticated Vite proxy.
+const cloudRpcEnabled = import.meta.env?.PROD === true || !!proxyPath
+
+// Browsers cannot add WebSocket auth headers. Vite supplies a local proxy path when a dev token is
+// configured, and adds the Authorization header on the server.
+const getCloudRpcEndpoint = (endpoint: string): string => {
+	if (!proxyPath || typeof window === 'undefined') return endpoint
+
+	const url = new URL(
+		`${proxyPath}${new URL(endpoint).pathname}`,
+		window.location.origin,
+	)
+	url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+	return url.href
+}
 
 export const DefaultRpcProviderByChain: Partial<Record<RpcChainId, string>> =
-	isProduction ? { statemint: 'Polkadot Cloud' } : {}
+	cloudRpcEnabled
+		? { statemint: 'Polkadot Cloud', 'people-polkadot': 'Polkadot Cloud' }
+		: {}
 
 export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
 	polkadot: {
@@ -39,6 +55,9 @@ export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
 		StakeWorld: 'wss://pas-rpc.stakeworld.io',
 	},
 	'people-polkadot': {
+		...(cloudRpcEnabled
+			? { 'Polkadot Cloud': getCloudRpcEndpoint(PolkadotCloudRpcPeopleUrl) }
+			: {}),
 		PolkadotPeople: 'wss://polkadot-people-rpc.polkadot.io',
 		LuckyFriday: 'wss://rpc-people-polkadot.luckyfriday.io',
 		RadiumBlock: 'wss://people-polkadot.public.curie.radiumblock.co/ws',
@@ -61,7 +80,9 @@ export const RpcEndpointsByChain: Record<RpcChainId, RpcEndpoints> = {
 		Rotko: 'wss://people-paseo.rotko.net',
 	},
 	statemint: {
-		...(isProduction ? { 'Polkadot Cloud': PolkadotCloudRpcStatemintUrl } : {}),
+		...(cloudRpcEnabled
+			? { 'Polkadot Cloud': getCloudRpcEndpoint(PolkadotCloudRpcStatemintUrl) }
+			: {}),
 		DeServe: 'wss://asset-hub.polkadot.rpc.deserve.network',
 		// LuckyFriday: 'wss://rpc-asset-hub-polkadot.luckyfriday.io',
 		// Parity: 'wss://polkadot-asset-hub-rpc.polkadot.io',

--- a/packages/tests/src/cloudRpc.test.ts
+++ b/packages/tests/src/cloudRpc.test.ts
@@ -1,0 +1,216 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { createHash } from 'node:crypto'
+import { once } from 'node:events'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer as createHttpServer, request } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { createServer, resolveConfig, type ViteDevServer } from 'vite'
+import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
+import { cloudRpcPlugin } from '../../vite-shared/src/index'
+
+const token = 'test-dev-token'
+const proxyRoute = '^/__cloud_rpc/(statemint|people)$'
+let root: string
+let vite: ViteDevServer
+let origin: string
+const upstreamRequests: { url?: string; authorization?: string }[] = []
+const upstream = createHttpServer()
+
+beforeAll(async () => {
+	root = await mkdtemp(path.join(tmpdir(), 'cloud-rpc-'))
+	await writeFile(path.join(root, 'pnpm-workspace.yaml'), 'packages: []\n')
+	await writeFile(path.join(root, '.env'), `CLOUD_RPC_AUTH_TOKEN=${token}\n`)
+	vi.stubEnv('CLOUD_RPC_AUTH_TOKEN', token)
+
+	upstream.on('upgrade', (req, socket) => {
+		upstreamRequests.push({
+			url: req.url,
+			authorization: req.headers.authorization,
+		})
+		const accept = createHash('sha1')
+			.update(
+				`${req.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`,
+			)
+			.digest('base64')
+		socket.end(
+			`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`,
+		)
+	})
+	upstream.listen(0, '127.0.0.1')
+	await once(upstream, 'listening')
+	const upstreamPort = (upstream.address() as AddressInfo).port
+
+	vite = await createServer({
+		root,
+		configFile: false,
+		logLevel: 'silent',
+		plugins: [
+			cloudRpcPlugin(),
+			{
+				name: 'local-test-upstream',
+				config: () => ({
+					server: {
+						proxy: {
+							[proxyRoute]: { target: `http://127.0.0.1:${upstreamPort}` },
+						},
+					},
+				}),
+			},
+		],
+		server: { host: '127.0.0.1', port: 0, ws: false },
+	})
+	await vite.listen()
+	origin = `http://127.0.0.1:${(vite.httpServer!.address() as AddressInfo).port}`
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+	vi.unstubAllEnvs()
+	vi.resetModules()
+})
+
+afterAll(async () => {
+	await vite?.close()
+	upstream.close()
+	if (root) await rm(root, { recursive: true, force: true })
+})
+
+test.each(['statemint', 'people'])(
+	'adds Bearer auth to the %s WebSocket upgrade',
+	async (chain) => {
+		await new Promise<void>((resolve, reject) => {
+			const req = request(`${origin}/__cloud_rpc/${chain}`, {
+				headers: {
+					Connection: 'Upgrade',
+					Upgrade: 'websocket',
+					'Sec-WebSocket-Version': '13',
+					'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+				},
+			})
+			req.on('upgrade', (_, socket) => {
+				socket.destroy()
+				resolve()
+			})
+			req.on('error', reject)
+			req.on('response', (response) => {
+				response.resume()
+				reject(
+					new Error(`Expected WebSocket upgrade, got ${response.statusCode}`),
+				)
+			})
+			req.setTimeout(3000, () => req.destroy(new Error('Upgrade timed out')))
+			req.end()
+		})
+		expect(upstreamRequests.at(-1)).toEqual({
+			url: `/${chain}`,
+			authorization: `Bearer ${token}`,
+		})
+	},
+)
+
+test('does not proxy any other RPC path', async () => {
+	const count = upstreamRequests.length
+	for (const route of ['relay', 'statemint/extra', 'people-other']) {
+		const response = await fetch(`${origin}/__cloud_rpc/${route}`)
+		expect(response.status).toBe(404)
+	}
+	expect(upstreamRequests).toHaveLength(count)
+})
+
+test('exposes only the proxy path to client code', () => {
+	expect(vite.config.define).toEqual({
+		'import.meta.env.CLOUD_RPC_PROXY_PATH': '"/__cloud_rpc"',
+	})
+	expect(JSON.stringify(vite.config.env)).not.toContain(token)
+})
+
+test.each(['http://localhost:5173', 'https://dev.example.test'])(
+	'routes only Cloud endpoints through the development origin %s',
+	async (devOrigin) => {
+		vi.stubEnv('PROD', false)
+		vi.stubEnv('CLOUD_RPC_PROXY_PATH', '/__cloud_rpc')
+		vi.stubGlobal('window', { location: { origin: devOrigin } })
+		const { RpcEndpointsByChain, getRpcEndpointList } = await import(
+			'../../consts/src/rpc'
+		)
+		const wsOrigin = devOrigin.replace(/^http/, 'ws')
+		expect(RpcEndpointsByChain.statemint['Polkadot Cloud']).toBe(
+			`${wsOrigin}/__cloud_rpc/statemint`,
+		)
+		expect(RpcEndpointsByChain['people-polkadot']['Polkadot Cloud']).toBe(
+			`${wsOrigin}/__cloud_rpc/people`,
+		)
+		expect(getRpcEndpointList('statemint')).toContain(
+			'wss://asset-hub.polkadot.rpc.deserve.network',
+		)
+		expect(getRpcEndpointList('polkadot')).not.toContain(
+			expect.stringContaining('/__cloud_rpc/'),
+		)
+	},
+)
+
+test('keeps direct Cloud endpoints and defaults in production without a token', async () => {
+	vi.stubEnv('PROD', true)
+	vi.stubEnv('CLOUD_RPC_AUTH_TOKEN', undefined)
+	vi.stubEnv('CLOUD_RPC_PROXY_PATH', undefined)
+	const { DefaultRpcProviderByChain, RpcEndpointsByChain } = await import(
+		'../../consts/src/rpc'
+	)
+	expect(RpcEndpointsByChain.statemint['Polkadot Cloud']).toBe(
+		'wss://rpc.polkadot.cloud/statemint',
+	)
+	expect(RpcEndpointsByChain['people-polkadot']['Polkadot Cloud']).toBe(
+		'wss://rpc.polkadot.cloud/people',
+	)
+	expect(DefaultRpcProviderByChain.statemint).toBe('Polkadot Cloud')
+	expect(DefaultRpcProviderByChain['people-polkadot']).toBe('Polkadot Cloud')
+})
+
+test.each([undefined, ''])(
+	'omits Cloud endpoints and defaults in development without a proxy (%s)',
+	async (proxyPath) => {
+		vi.stubEnv('PROD', false)
+		vi.stubEnv('CLOUD_RPC_PROXY_PATH', proxyPath)
+		const {
+			DefaultRpcProviderByChain,
+			RpcEndpointsByChain,
+			getRpcEndpointList,
+		} = await import('../../consts/src/rpc')
+		for (const chain of ['statemint', 'people-polkadot'] as const) {
+			expect(RpcEndpointsByChain[chain]).not.toHaveProperty('Polkadot Cloud')
+			expect(DefaultRpcProviderByChain[chain]).toBeUndefined()
+			const endpoints = getRpcEndpointList(chain)
+			expect(endpoints.length).toBeGreaterThan(0)
+			expect(
+				endpoints.every((url) => !url.includes('rpc.polkadot.cloud')),
+			).toBe(true)
+		}
+	},
+)
+
+test('omits the proxy and client override from production builds', async () => {
+	const config = await resolveConfig(
+		{ root, configFile: false, plugins: [cloudRpcPlugin()] },
+		'build',
+	)
+	expect(config.server.proxy).toBeUndefined()
+	expect(
+		config.define?.['import.meta.env.CLOUD_RPC_PROXY_PATH'],
+	).toBeUndefined()
+})
+
+test('omits the proxy when no token is configured', async () => {
+	vi.stubEnv('CLOUD_RPC_AUTH_TOKEN', '')
+	const config = await resolveConfig(
+		{ root, configFile: false, plugins: [cloudRpcPlugin()] },
+		'serve',
+	)
+	expect(config.server.proxy).toBeUndefined()
+	expect(
+		config.define?.['import.meta.env.CLOUD_RPC_PROXY_PATH'],
+	).toBeUndefined()
+})

--- a/packages/vite-shared/src/cloudRpc.ts
+++ b/packages/vite-shared/src/cloudRpc.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 @polkadot-cloud/polkadot-cloud-apps authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { loadEnv, type Plugin, searchForWorkspaceRoot } from 'vite'
+
+const proxyPath = '/__cloud_rpc'
+
+// Dedot's custom WebSocket headers only work in Node.js/Bun. Keep the dev token in Vite's server
+// and proxy only the two authenticated Polkadot Cloud RPC endpoints.
+export const cloudRpcPlugin = (): Plugin => ({
+	name: 'polkadot-cloud-rpc',
+	apply: (_, { command, isPreview }) => command === 'serve' && !isPreview,
+	config(config, { mode }) {
+		const envDir = searchForWorkspaceRoot(config.root ?? process.cwd())
+		const token = loadEnv(
+			mode,
+			envDir,
+			'CLOUD_RPC_AUTH_TOKEN',
+		).CLOUD_RPC_AUTH_TOKEN?.trim()
+		if (!token) return
+
+		return {
+			define: {
+				'import.meta.env.CLOUD_RPC_PROXY_PATH': JSON.stringify(proxyPath),
+			},
+			server: {
+				proxy: {
+					[`^${proxyPath}/(statemint|people)$`]: {
+						target: 'https://rpc.polkadot.cloud',
+						ws: true,
+						changeOrigin: true,
+						headers: { Authorization: `Bearer ${token}` },
+						rewrite: (path) => path.slice(proxyPath.length),
+					},
+				},
+			},
+		}
+	},
+})

--- a/packages/vite-shared/src/index.ts
+++ b/packages/vite-shared/src/index.ts
@@ -6,6 +6,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Plugin } from 'vite'
 
+export { cloudRpcPlugin } from './cloudRpc.ts'
+
 const faviconDir = fileURLToPath(new URL('../public/favicons', import.meta.url))
 
 const contentTypes: Record<string, string> = {


### PR DESCRIPTION
Enable authenticated development access to the Polkadot Cloud Statemint and People RPCs across Staking, Nominate, Swap, and Validators. The shared Vite proxy reads `CLOUD_RPC_AUTH_TOKEN` from the repository root `.env` and adds `Authorization: Bearer <token>` to the upstream WebSocket handshake. This is necessary because Dedot's custom WebSocket headers are not supported in browsers.

Register the People endpoint and prefer Polkadot Cloud for both chains when available. Development omits both Cloud endpoints and their default selections when no token is configured. Production continues connecting directly using the existing origin access rules; builds and preview exclude the proxy, and the token is never exposed to client code.

For local setup, put the raw token in `CLOUD_RPC_AUTH_TOKEN` without the `Bearer` prefix and restart Vite.

Validation:

- Full test suite passes: 318 tests, including 11 RPC proxy/configuration cases covering handshake headers, endpoint restrictions, missing-token behavior, and production configuration.
- Lint, all four app build checks, license headers, and locale validation passed.
- Both live Cloud endpoints returned their chain names through the development proxy using a WebSocket client without auth headers.
- Generated build output was checked for the actual token and development proxy URL; neither was present, including in the production Staking bundle.
